### PR TITLE
return return atf_no_error()

### DIFF
--- a/tests/lib/libc/sys/t_listen.c
+++ b/tests/lib/libc/sys/t_listen.c
@@ -132,5 +132,5 @@ ATF_TP_ADD_TCS(tp)
 	ATF_TP_ADD_TC(tp, listen_err);
 	ATF_TP_ADD_TC(tp, listen_low_port);
 
-	return 0;
+	return atf_no_error();
 }


### PR DESCRIPTION
instead of 0 for consistency