### PR TITLE
Fixing a public but almost undocumented speculative execution vulnerability that is specific to aarch64

### DIFF
--- a/sys/arch/aarch64/aarch64/cpuswitch.S
+++ b/sys/arch/aarch64/aarch64/cpuswitch.S
@@ -269,6 +269,8 @@ ENTRY_NP(el1_trap_exit)
 	ldr	x0, [x0, #TF_X0]
 
 	eret
+	dsb nsh
+	isb
 END(el1_trap_exit)
 #ifdef DDB
 END(el1_trap)
@@ -340,6 +342,8 @@ ENTRY_NP(el0_trap_exit)
 
 	/* leave sp at l_md.md_utf, return back to EL0 user process */
 	eret
+	dsb nsh
+	isb
 END(el0_trap_exit)
 #ifdef DDB
 END(el0_trap)


### PR DESCRIPTION
Even though ERET always causes a jump to another address, aarch64 CPUs
speculatively execute following instructions as if the ERET
instruction was not a jump instruction.
The speculative execution does not cross privilege-levels (to the jump
target as one would expect), but it continues on the kernel privilege
level as if the ERET instruction did not change the control flow -
thus executing anything that is accidentally linked after the ERET
instruction. Later, the results of this speculative execution are
always architecturally discarded, however they can leak data using
microarchitectural side channels. This speculative execution is very
reliable (seems to be unconditional) and it manages to complete even
relatively performance-heavy operations (e.g. multiple dependent
fetches from uncached memory).

It was quietly fixed in Linux by this patch:
https://github.com/torvalds/linux/commit/679db70801da9fda91d26caf13bf5b5ccc74e8e8

And the misbehavior is demonstrated by this implementation:
https://github.com/google/safeside/blob/master/demos/eret_hvc_smc_wrapper.cc
https://github.com/google/safeside/blob/master/kernel_modules/kmod_eret_hvc_smc/eret_hvc_smc_module.c