### PR TITLE
tail: Do not trust st_size if it equals zero

### DIFF
--- a/usr.bin/tail/forward.c
+++ b/usr.bin/tail/forward.c
@@ -96,7 +96,7 @@ forward(FILE *fp, enum STYLE style, off_t off, struct stat *sbp)
 	case FBYTES:
 		if (off == 0)
 			break;
-		if (S_ISREG(sbp->st_mode)) {
+		if (S_ISREG(sbp->st_mode) && sbp->st_size > 0) {
 			if (sbp->st_size < off)
 				off = sbp->st_size;
 			if (fseeko(fp, off, SEEK_SET) == -1) {
@@ -128,7 +128,7 @@ forward(FILE *fp, enum STYLE style, off_t off, struct stat *sbp)
 		}
 		break;
 	case RBYTES:
-		if (S_ISREG(sbp->st_mode)) {
+		if (S_ISREG(sbp->st_mode) && sbp->st_size > 0) {
 			if (sbp->st_size >= off &&
 			    fseeko(fp, -off, SEEK_END) == -1) {
 				ierr();
@@ -146,7 +146,7 @@ forward(FILE *fp, enum STYLE style, off_t off, struct stat *sbp)
 		}
 		break;
 	case RLINES:
-		if (S_ISREG(sbp->st_mode)) {
+		if (S_ISREG(sbp->st_mode) && sbp->st_size > 0) {
 			if (!off) {
 				if (fseek(fp, 0L, SEEK_END) == -1) {
 					ierr();


### PR DESCRIPTION
tail(1) is not able to operate on files residing in pseudo-filesystems or others that advertise a zero size.

To reproduce: `tail -1 /proc/mounts` dumps the whole file.

Also fixed on FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=276107