### PR TITLE
wc: Do not use st_size if it equals zero

### DIFF
--- a/usr.bin/wc/wc.c
+++ b/usr.bin/wc/wc.c
@@ -239,7 +239,7 @@ cnt(const char *file)
 				warn("%s", name);
 				rval = 1;
 			} else {
-				if (S_ISREG(sb.st_mode) ||
+				if ((S_ISREG(sb.st_mode) && sb.st_size > 0) ||
 				    S_ISLNK(sb.st_mode) ||
 				    S_ISDIR(sb.st_mode)) {
 					charct = sb.st_size;


### PR DESCRIPTION
wc(1) fails to read files on pseudo-filesystems with the -c option.

To reproduce:

```
$ wc -c /proc/cpuinfo
0
```

Also fixed in FreeBSD: https://github.com/freebsd/freebsd-src/pull/985