### PR TITLE
gzip: set file flags after setting file times

### DIFF
--- a/usr.bin/gzip/gzip.c
+++ b/usr.bin/gzip/gzip.c
@@ -1114,14 +1114,14 @@ copymodes(int fd, const struct stat *sbp, const char *file)
 	if (fchmod(fd, sb.st_mode) < 0)
 		maybe_warn("couldn't fchmod: %s", file);
 
-	/* only try flags if they exist already */
-        if (sb.st_flags != 0 && fchflags(fd, sb.st_flags) < 0)
-		maybe_warn("couldn't fchflags: %s", file);
-
 	TIMESPEC_TO_TIMEVAL(&times[0], &sb.st_atimespec);
 	TIMESPEC_TO_TIMEVAL(&times[1], &sb.st_mtimespec);
 	if (futimes(fd, times) < 0)
 		maybe_warn("couldn't utimes: %s", file);
+
+	/* only try flags if they exist already */
+        if (sb.st_flags != 0 && fchflags(fd, sb.st_flags) < 0)
+		maybe_warn("couldn't fchflags: %s", file);
 }
 #endif
 


### PR DESCRIPTION
gzip(1) cannot preserve the file's times because it first sets the file's flags. 

To reproduce:

```
$ /usr/bin/touch /tmp/foo
$ /bin/chflags uchg /tmp/foo
$ /usr/bin/gzip -v /tmp/foo
gzip: couldn't utimes: /tmp/foo.gz: Operation not permitted
/tmp/foo:         -99.9% -- replaced with /tmp/foo.gz
```

Already fixed in FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=120208