### PR TITLE
cp: Do not trust st_size if it equals zero

### DIFF
--- a/bin/cp/utils.c
+++ b/bin/cp/utils.c
@@ -180,9 +180,9 @@ copy_file(FTSENT *entp, int dne)
 
 	/* 
 	 * There's no reason to do anything other than close the file
-	 * now if it's regular and empty, so let's not bother.
+	 * now if it's not regular and empty, so let's not bother.
 	 */
-	bool need_copy = !S_ISREG(fs->st_mode) || fs->st_size > 0;
+	bool need_copy = S_ISREG(fs->st_mode) ? fs->st_size >= 0 : fs->st_size > 0;
 
 	struct finfo fi;
 


### PR DESCRIPTION
cp(1) cannot operate on files residing on pseudo-filesystems.

To reproduce:

```
$ cp /proc/mounts /tmp
$ ls -l /tmp/mounts
-r--r--r--  1 ricardo  wheel  0 Jan 14 19:30 /tmp/mounts
```

