### PR TITLE
gzip: Use fts_path instead of fts_name to get full path on messages

### DIFF
--- a/usr.bin/gzip/gzip.c
+++ b/usr.bin/gzip/gzip.c
@@ -2037,7 +2037,7 @@ handle_dir(char *dir)
 
 	path_argv[0] = dir;
 	path_argv[1] = 0;
-	fts = fts_open(path_argv, FTS_PHYSICAL, NULL);
+	fts = fts_open(path_argv, FTS_PHYSICAL | FTS_NOCHDIR, NULL);
 	if (fts == NULL) {
 		warn("couldn't fts_open %s", dir);
 		return;
@@ -2055,7 +2055,7 @@ handle_dir(char *dir)
 			maybe_warn("%s", entry->fts_path);
 			continue;
 		case FTS_F:
-			handle_file(entry->fts_name, entry->fts_statp);
+			handle_file(entry->fts_path, entry->fts_statp);
 		}
 	}
 	(void)fts_close(fts);


### PR DESCRIPTION
The handle_dir() function should pass fts_path and not fts_name because the latter is the basename(3).  Because of this, not just verbose output but error messages as well are ambiguous when files with the same name exist.

To reproduce:

```
$ mkdir /tmp/x /tmp/y
$ cp /etc/services /tmp/x
$ cp /etc/services /tmp/y
$ chmod 000 /tmp/x/services
$ gzip -vr /tmp/x /tmp/y
gzip: can't open services: Permission denied
services:          86.1% -- replaced with services.gz
```

With patch:

```
gzip: can't open /tmp/x/services: Permission denied
/tmp/y/services:	   86.1% -- replaced with /tmp/y/services.gz
```

Fixed in FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=114470