### PR TITLE
ext2fs: Drop EXT2FS_SYSTEM_FLAGS option and enforce its semantics

### DIFF
--- a/share/man/man4/options.4
+++ b/share/man/man4/options.4
@@ -1132,22 +1132,6 @@ created for another architecture.
 Increase lookup performance by maintaining in-core hash tables
 for large directories.
 .El
-.Ss Options for the ext2fs File System
-.Bl -ohang
-.It Cd options EXT2FS_SYSTEM_FLAGS
-This option changes the behavior of the APPEND and IMMUTABLE flags
-for a file on an
-.Em ext2
-file system.
-Without this option, the superuser or owner of the file can
-set and clear them.
-With this option, only the superuser can set them, and
-they can't be cleared if the securelevel is greater than 0.
-See also
-.Xr chflags 1
-and
-.Xr secmodel_securelevel 9 .
-.El
 .Ss Options for the NFS File System
 .Bl -ohang
 .It Cd options NFS_BOOT_BOOTP

--- a/sys/arch/amd64/conf/ALL
+++ b/sys/arch/amd64/conf/ALL
@@ -214,8 +214,6 @@ options 	LFS_KERNEL_RFW
 options 	LFS_QUOTA	# quotas for LFS - experimental
 options 	LFS_QUOTA2	# new-style quotas for LFS - experimental
 # ext2fs
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # other
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server

--- a/sys/arch/amd64/conf/GENERIC
+++ b/sys/arch/amd64/conf/GENERIC
@@ -215,8 +215,6 @@ options 	WAPBL		# File system journaling support
 # lfs
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH
 # ext2fs
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # other
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server

--- a/sys/arch/amd64/conf/XEN3_DOM0
+++ b/sys/arch/amd64/conf/XEN3_DOM0
@@ -210,8 +210,6 @@ options 	WAPBL		# File system journaling support
 # lfs
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH
 # ext2fs
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # other
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server

--- a/sys/arch/amd64/conf/XEN3_DOMU
+++ b/sys/arch/amd64/conf/XEN3_DOMU
@@ -91,8 +91,6 @@ options 	WAPBL		# File system journaling support
 # lfs
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH
 # ext2fs
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # other
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server

--- a/sys/arch/amiga/conf/DRACO
+++ b/sys/arch/amiga/conf/DRACO
@@ -112,8 +112,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 #

--- a/sys/arch/amiga/conf/GENERIC
+++ b/sys/arch/amiga/conf/GENERIC
@@ -127,8 +127,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	NFSSERVER	# Network File System server
 
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 #
 # Compatibility options for various existing systems

--- a/sys/arch/amiga/conf/GENERIC.in
+++ b/sys/arch/amiga/conf/GENERIC.in
@@ -168,8 +168,6 @@ options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	NFSSERVER	# Network File System server
 ')m4_dnl
 
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 #
 # Compatibility options for various existing systems

--- a/sys/arch/amiga/conf/INSTALL
+++ b/sys/arch/amiga/conf/INSTALL
@@ -105,8 +105,6 @@ file-system 	KERNFS		# kernel data-structure filesystem
 options 	WAPBL		# File system journaling support
 
 
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 #
 # Compatibility options for various existing systems

--- a/sys/arch/amigappc/conf/GENERIC
+++ b/sys/arch/amigappc/conf/GENERIC
@@ -114,8 +114,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 #

--- a/sys/arch/amigappc/conf/NULL
+++ b/sys/arch/amigappc/conf/NULL
@@ -97,8 +97,6 @@ file-system	TMPFS		# Efficient memory file-system
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 #

--- a/sys/arch/arc/conf/ARCTIC
+++ b/sys/arch/arc/conf/ARCTIC
@@ -76,8 +76,6 @@ options 	QUOTA		# legacy UFS quotas
 options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	FFS_EI		# FFS Endian Independent support
 options 	NFSSERVER	# Network File System server
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 
 # Networking options

--- a/sys/arch/arc/conf/GENERIC
+++ b/sys/arch/arc/conf/GENERIC
@@ -112,8 +112,6 @@ file-system	TMPFS		# Efficient memory file-system
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/arc/conf/M403
+++ b/sys/arch/arc/conf/M403
@@ -70,8 +70,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	FFS_EI		# FFS Endian Independent support
 options 	NFSSERVER	# Network File System server
 #options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# IP packet forwarding

--- a/sys/arch/arc/conf/MIMORI
+++ b/sys/arch/arc/conf/MIMORI
@@ -71,8 +71,6 @@ file-system	PTYFS		# /dev/pts/N support
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	FFS_EI		# FFS Endian Independent support
 options 	NFSSERVER	# Network File System server
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 
 # Networking options

--- a/sys/arch/arc/conf/PICA
+++ b/sys/arch/arc/conf/PICA
@@ -71,8 +71,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	FFS_EI		# FFS Endian Independent support
 options 	NFSSERVER	# Network File System server
 #options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# IP packet forwarding

--- a/sys/arch/arc/conf/RPC44
+++ b/sys/arch/arc/conf/RPC44
@@ -98,8 +98,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	FFS_EI		# FFS Endian Independent support
 options 	NFSSERVER	# Network File System server
 #options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# IP packet forwarding

--- a/sys/arch/atari/conf/GENERIC.in
+++ b/sys/arch/atari/conf/GENERIC.in
@@ -133,8 +133,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	QUOTA		# legacy UFS quotas
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 #endif /* !SMALL030_KERNEL */
 

--- a/sys/arch/bebox/conf/GENERIC
+++ b/sys/arch/bebox/conf/GENERIC
@@ -90,8 +90,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/cobalt/conf/GENERIC
+++ b/sys/arch/cobalt/conf/GENERIC
@@ -83,8 +83,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/cobalt/conf/INSTALL
+++ b/sys/arch/cobalt/conf/INSTALL
@@ -74,8 +74,6 @@ file-system	MFS		# memory-based filesystem
 #options 	FFS_EI		# FFS Endian Independent support
 options 	WAPBL		# File system journaling support
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# IP packet forwarding

--- a/sys/arch/dreamcast/conf/G1IDE
+++ b/sys/arch/dreamcast/conf/G1IDE
@@ -78,8 +78,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/dreamcast/conf/GENERIC
+++ b/sys/arch/dreamcast/conf/GENERIC
@@ -89,8 +89,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/epoc32/conf/GENERIC
+++ b/sys/arch/epoc32/conf/GENERIC
@@ -54,8 +54,6 @@ options 	FFS_EI		# FFS Endian Independent support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/ARMADILLO210
+++ b/sys/arch/evbarm/conf/ARMADILLO210
@@ -46,8 +46,6 @@ file-system	NFS		# Network file system
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/ARMADILLO9
+++ b/sys/arch/evbarm/conf/ARMADILLO9
@@ -46,8 +46,6 @@ file-system	PTYFS		# /dev/pts/N support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/CUBOX
+++ b/sys/arch/evbarm/conf/CUBOX
@@ -114,8 +114,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/GENERIC.common
+++ b/sys/arch/evbarm/conf/GENERIC.common
@@ -38,8 +38,6 @@ options 	WAPBL		# File system journaling support
 # lfs
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH
 # ext2fs
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # other
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server

--- a/sys/arch/evbarm/conf/GUMSTIX
+++ b/sys/arch/evbarm/conf/GUMSTIX
@@ -68,8 +68,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/HDL_G
+++ b/sys/arch/evbarm/conf/HDL_G
@@ -55,8 +55,6 @@ file-system	UNION		# union file system
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/HPT5325
+++ b/sys/arch/evbarm/conf/HPT5325
@@ -62,8 +62,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/IYONIX
+++ b/sys/arch/evbarm/conf/IYONIX
@@ -129,8 +129,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/evbarm/conf/MARVELL_NAS
+++ b/sys/arch/evbarm/conf/MARVELL_NAS
@@ -59,8 +59,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/MMNET_GENERIC
+++ b/sys/arch/evbarm/conf/MMNET_GENERIC
@@ -124,8 +124,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/MPCSA_GENERIC
+++ b/sys/arch/evbarm/conf/MPCSA_GENERIC
@@ -125,8 +125,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/MV2120
+++ b/sys/arch/evbarm/conf/MV2120
@@ -63,8 +63,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/OPENBLOCKS_A6
+++ b/sys/arch/evbarm/conf/OPENBLOCKS_A6
@@ -60,8 +60,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbarm/conf/SHEEVAPLUG
+++ b/sys/arch/evbarm/conf/SHEEVAPLUG
@@ -62,8 +62,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/ADM5120
+++ b/sys/arch/evbmips/conf/ADM5120
@@ -66,8 +66,6 @@ file-system	NFS		# Sun NFS-compatible filesystem client
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/ADM5120-NB
+++ b/sys/arch/evbmips/conf/ADM5120-NB
@@ -66,8 +66,6 @@ file-system	NFS		# Sun NFS-compatible filesystem client
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/ADM5120-USB
+++ b/sys/arch/evbmips/conf/ADM5120-USB
@@ -65,8 +65,6 @@ file-system	NFS		# Sun NFS-compatible filesystem client
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/ALCHEMY
+++ b/sys/arch/evbmips/conf/ALCHEMY
@@ -78,8 +78,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/AP30
+++ b/sys/arch/evbmips/conf/AP30
@@ -78,8 +78,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/CI20
+++ b/sys/arch/evbmips/conf/CI20
@@ -88,8 +88,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/CPMBR1400
+++ b/sys/arch/evbmips/conf/CPMBR1400
@@ -88,8 +88,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	QUOTA		# legacy UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/DB120
+++ b/sys/arch/evbmips/conf/DB120
@@ -87,8 +87,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/LINKITSMART7688
+++ b/sys/arch/evbmips/conf/LINKITSMART7688
@@ -91,8 +91,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	QUOTA		# legacy UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/MALTA
+++ b/sys/arch/evbmips/conf/MALTA
@@ -73,8 +73,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	QUOTA		# legacy UFS quotas
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/MERAKI
+++ b/sys/arch/evbmips/conf/MERAKI
@@ -79,8 +79,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/MIPSSIM
+++ b/sys/arch/evbmips/conf/MIPSSIM
@@ -78,8 +78,6 @@ options 	FFS_EI		# FFS Endian Independent support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/OCTEON
+++ b/sys/arch/evbmips/conf/OCTEON
@@ -83,8 +83,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/RB153
+++ b/sys/arch/evbmips/conf/RB153
@@ -61,8 +61,6 @@ file-system	NULLFS		# NULL layered filesystem
 #options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbmips/conf/RB433UAH
+++ b/sys/arch/evbmips/conf/RB433UAH
@@ -79,8 +79,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/SBMIPS
+++ b/sys/arch/evbmips/conf/SBMIPS
@@ -68,8 +68,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/WGT624V3
+++ b/sys/arch/evbmips/conf/WGT624V3
@@ -80,8 +80,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/XLSATX
+++ b/sys/arch/evbmips/conf/XLSATX
@@ -78,8 +78,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Alternate buffer queue strategies for better responsiveness under high

--- a/sys/arch/evbmips/conf/ZYXELKX
+++ b/sys/arch/evbmips/conf/ZYXELKX
@@ -88,8 +88,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	QUOTA		# legacy UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/DHT
+++ b/sys/arch/evbppc/conf/DHT
@@ -97,8 +97,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/EV64260
+++ b/sys/arch/evbppc/conf/EV64260
@@ -96,8 +96,6 @@ file-system 	MSDOSFS		# MS-DOS file system
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/EXPLORA451
+++ b/sys/arch/evbppc/conf/EXPLORA451
@@ -87,8 +87,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/evbppc/conf/MPC8536DS
+++ b/sys/arch/evbppc/conf/MPC8536DS
@@ -85,8 +85,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/MPC8548CDS
+++ b/sys/arch/evbppc/conf/MPC8548CDS
@@ -87,8 +87,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/OPENBLOCKS200
+++ b/sys/arch/evbppc/conf/OPENBLOCKS200
@@ -79,8 +79,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/OPENBLOCKS266
+++ b/sys/arch/evbppc/conf/OPENBLOCKS266
@@ -94,8 +94,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root
 

--- a/sys/arch/evbppc/conf/OPENBLOCKS600
+++ b/sys/arch/evbppc/conf/OPENBLOCKS600
@@ -94,8 +94,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/P2020DS
+++ b/sys/arch/evbppc/conf/P2020DS
@@ -93,8 +93,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/P2020RDB
+++ b/sys/arch/evbppc/conf/P2020RDB
@@ -88,8 +88,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/PMPPC
+++ b/sys/arch/evbppc/conf/PMPPC
@@ -76,8 +76,6 @@ options 	FFS_EI		# FFS Endian Independent support
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/RB800
+++ b/sys/arch/evbppc/conf/RB800
@@ -90,8 +90,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/RB850GX2
+++ b/sys/arch/evbppc/conf/RB850GX2
@@ -87,8 +87,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/TWRP1025
+++ b/sys/arch/evbppc/conf/TWRP1025
@@ -87,8 +87,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/evbppc/conf/VIRTEX_DFC
+++ b/sys/arch/evbppc/conf/VIRTEX_DFC
@@ -87,8 +87,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/VIRTEX_GSRD1
+++ b/sys/arch/evbppc/conf/VIRTEX_GSRD1
@@ -81,8 +81,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/VIRTEX_GSRD2
+++ b/sys/arch/evbppc/conf/VIRTEX_GSRD2
@@ -89,8 +89,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/evbppc/conf/WALNUT
+++ b/sys/arch/evbppc/conf/WALNUT
@@ -75,8 +75,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/ews4800mips/conf/GENERIC
+++ b/sys/arch/ews4800mips/conf/GENERIC
@@ -106,8 +106,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/hp300/conf/GENERIC
+++ b/sys/arch/hp300/conf/GENERIC
@@ -115,8 +115,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/hp300/conf/INSTALL
+++ b/sys/arch/hp300/conf/INSTALL
@@ -109,8 +109,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/hpcsh/conf/GENERIC
+++ b/sys/arch/hpcsh/conf/GENERIC
@@ -133,8 +133,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 options 	INET		# IP + ICMP + TCP + UDP

--- a/sys/arch/hppa/conf/GENERIC
+++ b/sys/arch/hppa/conf/GENERIC
@@ -113,8 +113,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/i386/conf/ALL
+++ b/sys/arch/i386/conf/ALL
@@ -200,8 +200,6 @@ options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH
 options 	LFS_QUOTA	# quotas for LFS - experimental
 options 	LFS_QUOTA2	# new-style quotas for LFS - experimental
 # ext2fs
-options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # other
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server

--- a/sys/arch/i386/conf/GENERIC
+++ b/sys/arch/i386/conf/GENERIC
@@ -168,8 +168,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 #options 	V7FS_EI		# V7FS Endian Independent support

--- a/sys/arch/i386/conf/GENERIC_PS2TINY
+++ b/sys/arch/i386/conf/GENERIC_PS2TINY
@@ -91,8 +91,6 @@ options 	QUOTA		# UFS quotas
 options 	WAPBL		# File system journaling support
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	NFSSERVER	# Network File System server
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 # Networking options
 #options 	GATEWAY		# packet forwarding
 options 	INET		# IP + ICMP + TCP + UDP

--- a/sys/arch/i386/conf/GENERIC_TINY
+++ b/sys/arch/i386/conf/GENERIC_TINY
@@ -86,8 +86,6 @@ file-system	KERNFS		# /kern
 #options 	FFS_EI		# FFS Endian Independent support
 #options 	NFSSERVER	# Network File System server
 options 	FFS_NO_SNAPSHOT	# No FF snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/i386/conf/INSTALL_FLOPPY
+++ b/sys/arch/i386/conf/INSTALL_FLOPPY
@@ -112,8 +112,6 @@ file-system	TMPFS		# Efficient memory file-system
 #options 	NFSSERVER	# Network File System server
 options 	NFS_V2_ONLY	# Exclude NFS3 code to save space
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/i386/conf/INSTALL_TINY
+++ b/sys/arch/i386/conf/INSTALL_TINY
@@ -98,8 +98,6 @@ file-system	MSDOSFS		# MS-DOS file system
 #options 	NFSSERVER	# Network File System server
 options 	NFS_V2_ONLY	# Exclude NFS3 code to save space
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/i386/conf/NET4501
+++ b/sys/arch/i386/conf/NET4501
@@ -109,8 +109,6 @@ file-system	PTYFS		# /dev/pts/N support
 #options 	FFS_EI		# FFS Endian Independent support
 #options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	NFSSERVER	# Network File System server
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 options 	GATEWAY		# packet forwarding

--- a/sys/arch/i386/conf/XEN3PAE_DOM0
+++ b/sys/arch/i386/conf/XEN3PAE_DOM0
@@ -125,8 +125,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/i386/conf/XEN3PAE_DOMU
+++ b/sys/arch/i386/conf/XEN3PAE_DOMU
@@ -111,8 +111,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 #options 	V7FS_EI		# V7FS Endian Independent support

--- a/sys/arch/ia64/conf/GENERIC
+++ b/sys/arch/ia64/conf/GENERIC
@@ -85,8 +85,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # These options enable verbose messages for several subsystems.

--- a/sys/arch/ia64/conf/GENERIC.SKI
+++ b/sys/arch/ia64/conf/GENERIC.SKI
@@ -85,8 +85,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/ibmnws/conf/GENERIC
+++ b/sys/arch/ibmnws/conf/GENERIC
@@ -49,8 +49,6 @@ file-system	TMPFS		# Efficient memory file-system
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 
 #options 	USERCONF	# userconf(4) support

--- a/sys/arch/iyonix/conf/GENERIC
+++ b/sys/arch/iyonix/conf/GENERIC
@@ -128,8 +128,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/landisk/conf/GENERIC
+++ b/sys/arch/landisk/conf/GENERIC
@@ -115,8 +115,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/mac68k/conf/GENERIC
+++ b/sys/arch/mac68k/conf/GENERIC
@@ -124,8 +124,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/macppc/conf/GENERIC
+++ b/sys/arch/macppc/conf/GENERIC
@@ -91,8 +91,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/macppc/conf/GENERIC_601
+++ b/sys/arch/macppc/conf/GENERIC_601
@@ -112,8 +112,6 @@ file-system	TMPFS		# Efficient memory file-system
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/macppc/conf/MAMBO
+++ b/sys/arch/macppc/conf/MAMBO
@@ -70,8 +70,6 @@ options 	QUOTA		# legacy UFS quotas
 options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/macppc/conf/POWERMAC_G5
+++ b/sys/arch/macppc/conf/POWERMAC_G5
@@ -85,8 +85,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/macppc/conf/POWERMAC_G5_11_2
+++ b/sys/arch/macppc/conf/POWERMAC_G5_11_2
@@ -67,8 +67,6 @@ file-system	PTYFS		# /dev/pts/N support
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/mmeye/conf/GENERIC
+++ b/sys/arch/mmeye/conf/GENERIC
@@ -105,8 +105,6 @@ file-system	TMPFS		# Efficient memory file-system
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 #options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/mmeye/conf/MMEYE_WLF
+++ b/sys/arch/mmeye/conf/MMEYE_WLF
@@ -101,8 +101,6 @@ file-system	TMPFS		# Efficient memory file-system
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/mmeye/conf/MMTA
+++ b/sys/arch/mmeye/conf/MMTA
@@ -79,8 +79,6 @@ file-system	PTYFS		# /dev/pts/N support
 options 	NFSSERVER	# Network File System server
 #options 	FIFO		# FIFOs; RECOMMENDED
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/mmeye/conf/MMTAICE
+++ b/sys/arch/mmeye/conf/MMTAICE
@@ -103,8 +103,6 @@ file-system	PTYFS		# /dev/pts/N support
 options 	NFSSERVER	# Network File System server
 #options 	FIFO		# FIFOs; RECOMMENDED
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/mmeye/conf/MMTAROMNEW
+++ b/sys/arch/mmeye/conf/MMTAROMNEW
@@ -90,8 +90,6 @@ file-system	PTYFS		# /dev/pts/N support
 #options 	NFSSERVER	# Network File System server
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	FIFO		# FIFOs; RECOMMENDED
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/mvmeppc/conf/GENERIC
+++ b/sys/arch/mvmeppc/conf/GENERIC
@@ -64,8 +64,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/next68k/conf/GENERIC
+++ b/sys/arch/next68k/conf/GENERIC
@@ -106,8 +106,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/next68k/conf/RAMDISK
+++ b/sys/arch/next68k/conf/RAMDISK
@@ -95,8 +95,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/next68k/conf/SLAB
+++ b/sys/arch/next68k/conf/SLAB
@@ -73,8 +73,6 @@ file-system	PTYFS		# /dev/pts/N support
 #options 	NFSSERVER	# nfs server support
 #options 	QUOTA		# legacy UFS quotas
 #options 	QUOTA2		# new, in-filesystem UFS quotas
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 
 # Networking options
 #options 	GATEWAY		# packet forwarding

--- a/sys/arch/ofppc/conf/GENERIC
+++ b/sys/arch/ofppc/conf/GENERIC
@@ -109,8 +109,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/prep/conf/GENERIC
+++ b/sys/arch/prep/conf/GENERIC
@@ -92,8 +92,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/prep/conf/INSTALL
+++ b/sys/arch/prep/conf/INSTALL
@@ -39,8 +39,6 @@ file-system 	MSDOSFS		# MS-DOS file system
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	FFS_EI		# FFS Endian Independent support
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
- 				# immutable) behave as system flags.
 options 	WAPBL		# File system journaling support
 
 #options 	USERCONF	# userconf(4) support

--- a/sys/arch/prep/conf/INSTALL_SMALL
+++ b/sys/arch/prep/conf/INSTALL_SMALL
@@ -41,8 +41,6 @@ file-system 	MSDOSFS		# MS-DOS file system
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	FFS_EI		# FFS Endian Independent support
 options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
- 				# immutable) behave as system flags.
 options 	WAPBL		# File system journaling support
 
 #options 	USERCONF	# userconf(4) support

--- a/sys/arch/riscv/conf/GENERIC.common
+++ b/sys/arch/riscv/conf/GENERIC.common
@@ -76,8 +76,6 @@ options 	QUOTA		# legacy UFS quotas
 options 	QUOTA2		# new, in-filesystem UFS quotas
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 options 	NFS_BOOT_DHCP	# Support DHCP NFS root

--- a/sys/arch/rs6000/conf/GENERIC
+++ b/sys/arch/rs6000/conf/GENERIC
@@ -98,8 +98,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/sandpoint/conf/GENERIC
+++ b/sys/arch/sandpoint/conf/GENERIC
@@ -105,8 +105,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 options 	NFSSERVER	# Network File System server
 

--- a/sys/arch/sbmips/conf/GENERIC
+++ b/sys/arch/sbmips/conf/GENERIC
@@ -71,8 +71,6 @@ options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
 options 	LFS_DIRHASH	# LFS version of UFS_DIRHASH - experimental
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/sgimips/conf/GENERIC32_IP12
+++ b/sys/arch/sgimips/conf/GENERIC32_IP12
@@ -92,8 +92,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/sgimips/conf/GENERIC32_IP2x
+++ b/sys/arch/sgimips/conf/GENERIC32_IP2x
@@ -88,8 +88,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/sgimips/conf/GENERIC32_IP3x
+++ b/sys/arch/sgimips/conf/GENERIC32_IP3x
@@ -81,8 +81,6 @@ options 	QUOTA2		# new, in-filesystem UFS quotas
 options 	UFS_DIRHASH	# UFS Large Directory Hashing
 options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 options 	NFSSERVER	# Network File System server
 
 # Networking options

--- a/sys/arch/zaurus/conf/GENERIC
+++ b/sys/arch/zaurus/conf/GENERIC
@@ -77,8 +77,6 @@ options 	FFS_NO_SNAPSHOT	# No FFS snapshot support
 #options 	UFS_DIRHASH	# UFS Large Directory Hashing
 #options 	UFS_EXTATTR	# Extended attribute support for UFS1
 options 	WAPBL		# File system journaling support
-#options 	EXT2FS_SYSTEM_FLAGS # makes ext2fs file flags (append and
-				# immutable) behave as system flags.
 #options 	DISKLABEL_EI	# disklabel Endian Independent support
 #options 	NFSSERVER	# Network File System server
 


### PR DESCRIPTION
On Linux, only root can set the immutable & append file flags. NetBSD _should_ stick with those semantics.

The default behaviour is allowing the user to set the immutable/append flags, which is problematic for at least 2 reasons:

1. The user setting the flag when only root should be allowed.
1. When the user sets those flags, he cannot unset them later when running on Linux, FreeBSD (and perhaps other systems).  Only root.

FreeBSD solved this issue already in 2009:

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=122047