### PR TITLE
stat: Allow -f %Sf to display the file flags symbolically

### DIFF
--- a/usr.bin/stat/Makefile
+++ b/usr.bin/stat/Makefile
@@ -14,4 +14,6 @@ COPTS.stat.c+=	${CC_WNO_IMPLICIT_FALLTHROUGH}
 
 COPTS.stat.c += -Wno-format-nonliteral
 
+LDADD=	-lutil
+
 .include <bsd.prog.mk>

--- a/usr.bin/stat/stat.1
+++ b/usr.bin/stat/stat.1
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 22, 2022
+.Dd January 29, 2023
 .Dt STAT 1
 .Os
 .Sh NAME
@@ -315,6 +315,11 @@ format with the extension that
 prints nanoseconds if available.
 .It Cm d , r
 Display actual device name.
+.It Cm f
+Display the flags of
+.Ar file
+as in
+.Nm ls Fl ldo .
 .It Cm g , u
 Display group or user name.
 .It Cm p

--- a/usr.bin/stat/stat.c
+++ b/usr.bin/stat/stat.c
@@ -63,6 +63,9 @@ __RCSID("$NetBSD: stat.c,v 1.48 2022/06/22 18:20:30 kre Exp $");
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#if HAVE_STRUCT_STAT_ST_FLAGS
+#include <util.h>
+#endif
 #include <vis.h>
 
 #if HAVE_STRUCT_STAT_ST_FLAGS
@@ -867,8 +870,9 @@ format1(const struct stat *st,
 	case SHOW_st_flags:
 		small = (sizeof(st->st_flags) == 4);
 		data = st->st_flags;
-		sdata = NULL;
-		formats = FMTF_DECIMAL | FMTF_OCTAL | FMTF_UNSIGNED | FMTF_HEX;
+		sdata = flags_to_string((u_long)st->st_flags, "-");
+		formats = FMTF_DECIMAL | FMTF_OCTAL | FMTF_UNSIGNED | FMTF_HEX |
+		    FMTF_STRING;
 		if (ofmt == 0)
 			ofmt = FMTF_UNSIGNED;
 		break;


### PR DESCRIPTION
 Allow `-f %Sf` to display the file flags symbolically.

With this patch:

```
$ touch /tmp/abc
$ chflags uchg /tmp/abc
$ ./stat -f '%Sf %N' /tmp/abc
uchg /tmp/abc
```
