### PR TITLE
ls: Print full path in error messages

### DIFF
--- a/bin/ls/ls.c
+++ b/bin/ls/ls.c
@@ -445,7 +445,7 @@ traverse(int argc, char *argv[], int options)
 			break;
 		case FTS_DNR:
 		case FTS_ERR:
-			warnx("%s: %s", p->fts_name, strerror(p->fts_errno));
+			warnx("%s: %s", p->fts_path, strerror(p->fts_errno));
 			rval = EXIT_FAILURE;
 			break;
 		case FTS_D:


### PR DESCRIPTION
To reproduce:

```
$ mkdir /tmp/a
$ chmod 000 /tmp/a
$ ls  /tmp/a/
ls: : Permission denied
$ ls /tmp/a
ls: a: Permission denied
```

Already fixed in FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=107515