### PR TITLE
cd9660: Add support for mask,dirmask,uid,gid options

### DIFF
--- a/sbin/mount_cd9660/Makefile
+++ b/sbin/mount_cd9660/Makefile
@@ -4,7 +4,7 @@
 .include <bsd.own.mk>
 
 PROG=	mount_cd9660
-SRCS=	mount_cd9660.c pathadj.c
+SRCS=	mount_cd9660.c fattr.c pathadj.c
 MAN=	mount_cd9660.8
 
 MOUNT=	${NETBSDSRCDIR}/sbin/mount

--- a/sbin/mount_cd9660/mount_cd9660.8
+++ b/sbin/mount_cd9660/mount_cd9660.8
@@ -57,7 +57,7 @@
 .\"
 .\"     @(#)mount_cd9660.8	8.3 (Berkeley) 3/27/94
 .\"
-.Dd June 30, 2018
+.Dd February 1, 2024
 .Dt MOUNT_CD9660 8
 .Os
 .Sh NAME
@@ -65,6 +65,10 @@
 .Nd mount an ISO-9660 file system
 .Sh SYNOPSIS
 .Nm
+.Op Fl G Ar gid
+.Op Fl m Ar mask
+.Op Fl M Ar mask
+.Op Fl U Ar uid
 .Op Fl o Ar options
 .Ar special node
 .Sh DESCRIPTION
@@ -82,6 +86,37 @@ are converted to absolute paths before use.
 .Pp
 The options are as follows:
 .Bl -tag -width indent
+.It Fl G Ar group
+Set the group of the files in the file system to
+.Ar group .
+The default gid on non-Rockridge volumes is zero.
+.It Fl U Ar user
+Set the owner of the files in the file system to
+.Ar user .
+The default uid on non-Rockridge volumes is zero.
+.It Fl m Ar mask
+Specify the maximum file permissions for files
+in the file system.
+(For example, a
+.Ar mask
+of
+.Li 755
+specifies that, by default, the owner should have
+read, write, and execute permissions for files, but
+others should only have read and execute permissions).
+See
+.Xr chmod 1
+for more information about octal file modes.
+Only the nine low-order bits of
+.Ar mask
+are used.
+The default
+.Ar mask
+on non-Rockridge volumes is 755.
+.It Fl M Ar mask
+Specify the maximum file permissions for directories
+in the file system.
+See the previous option's description for details.
 .It Fl o
 Options are specified with a
 .Fl o

--- a/sbin/mount_cd9660/mount_cd9660.c
+++ b/sbin/mount_cd9660/mount_cd9660.c
@@ -99,14 +99,15 @@ mount_cd9660_parseargs(int argc, char **argv,
 	struct iso_args *args, int *mntflags,
 	char *canon_dev, char *canon_dir)
 {
-	int ch, opts;
+	struct stat sb;
+	int ch, opts, set_gid, set_uid, set_mask, set_dirmask;
 	mntoptparse_t mp;
 	char *dev, *dir;
 
 	memset(args, 0, sizeof(*args));
-	*mntflags = opts = 0;
+	*mntflags = opts = set_gid = set_uid = set_mask = set_dirmask = 0;
 	optind = optreset = 1;
-	while ((ch = getopt(argc, argv, "egjo:r")) != -1)
+	while ((ch = getopt(argc, argv, "egG:jM:m:o:rU:")) != -1)
 		switch (ch) {
 		case 'e':
 			/* obsolete, retained for compatibility only, use
@@ -117,6 +118,19 @@ mount_cd9660_parseargs(int argc, char **argv,
 			/* obsolete, retained for compatibility only, use
 			 * -o gens */
 			opts |= ISOFSMNT_GENS;
+			break;
+		case 'G':
+			opts |= ISOFSMNT_GID;
+			args->gid = a_gid(optarg);
+			set_gid = 1;
+			break;
+		case 'm':
+			args->fmask = a_mask(optarg);
+			set_mask = 1;
+			break;
+		case 'M':
+			args->dmask = a_mask(optarg);
+			set_dirmask = 1;
 			break;
 		case 'j':
 			/* obsolete, retained fo compatibility only, use
@@ -134,6 +148,11 @@ mount_cd9660_parseargs(int argc, char **argv,
 			 * -o norrip */
 			opts |= ISOFSMNT_NORRIP;
 			break;
+		case 'U':
+			opts |= ISOFSMNT_UID;
+			args->uid = a_uid(optarg);
+			set_uid = 1;
+			break;
 		case '?':
 		default:
 			usage();
@@ -144,6 +163,14 @@ mount_cd9660_parseargs(int argc, char **argv,
 
 	if (argc != 2)
 		usage();
+
+	if (set_mask && !set_dirmask) {
+		args->dmask = args->fmask;
+		set_dirmask = 1;
+	} else if (set_dirmask && !set_mask) {
+		args->fmask = args->dmask;
+		set_mask = 1;
+	}
 
 	dev = argv[0];
 	dir = argv[1];
@@ -159,6 +186,20 @@ mount_cd9660_parseargs(int argc, char **argv,
 		*mntflags |= MNT_RDONLY;
 	args->fspec = canon_dev;
 	args->flags = opts;
+
+	if (!set_gid || !set_uid || !set_mask) {
+		if (stat(dir, &sb) == -1)
+			err(1, "stat %s", dir);
+
+		if (!set_uid)
+			args->uid = sb.st_uid;
+		if (!set_gid)
+			args->gid = sb.st_gid;
+		if (!set_mask) {
+			args->fmask = args->dmask =
+				sb.st_mode & (S_IRWXU | S_IRWXG | S_IRWXO);
+		}
+	}
 }
 
 int

--- a/sys/fs/cd9660/cd9660_extern.h
+++ b/sys/fs/cd9660/cd9660_extern.h
@@ -62,6 +62,11 @@ struct iso_mnt {
 	dev_t im_dev;
 	struct vnode *im_devvp;
 
+	uid_t	im_uid;
+	gid_t	im_gid;
+	mode_t	im_fmask;
+	mode_t	im_dmask;
+
 	int logical_block_size;
 	int im_bshift;
 	int im_bmask;

--- a/sys/fs/cd9660/cd9660_mount.h
+++ b/sys/fs/cd9660/cd9660_mount.h
@@ -45,6 +45,10 @@ struct iso_args {
 	const char	*fspec;		/* block special device to mount */
 	struct	export_args30 _pad1; /* compat with old userland tools */
 	int	flags;			/* mounting flags, see below */
+	uid_t	uid;			/* uid that owns ISO-9660 files */
+	gid_t	gid;			/* gid that owns ISO-9660 files */
+	mode_t	fmask;			/* file mask to be applied for files */
+	mode_t	dmask;			/* file mask to be applied for directories */
 };
 #define	ISOFSMNT_NORRIP		0x00000001 /* disable Rock Ridge Ext.*/
 #define	ISOFSMNT_GENS		0x00000002 /* enable generation numbers */
@@ -52,6 +56,8 @@ struct iso_args {
 #define	ISOFSMNT_NOJOLIET	0x00000008 /* disable Joliet extensions */
 #define	ISOFSMNT_NOCASETRANS	0x00000010 /* do not make names lower case */
 #define	ISOFSMNT_RRCASEINS	0x00000020 /* case insensitive Rock Ridge */
+#define	ISOFSMNT_UID		0x00000100 /* override uid */
+#define	ISOFSMNT_GID		0x00000200 /* override gid */
 
 #define ISOFSMNT_BITS "\177\20" \
     "b\00norrip\0b\01gens\0b\02extatt\0b\03nojoliet\0" \

--- a/sys/fs/cd9660/cd9660_vfsops.c
+++ b/sys/fs/cd9660/cd9660_vfsops.c
@@ -456,6 +456,13 @@ iso_mountfs(struct vnode *devvp, struct mount *mp, struct lwp *l,
 	isomp->im_dev = dev;
 	isomp->im_devvp = devvp;
 
+	if (argp->flags & ISOFSMNT_UID)
+		isomp->im_uid = argp->uid;
+	if (argp->flags & ISOFSMNT_GID)
+		isomp->im_gid = argp->gid;
+	isomp->im_fmask = argp->fmask & ACCESSPERMS;
+	isomp->im_dmask = argp->dmask & ACCESSPERMS;
+
 	/* Check the Rock Ridge Extension support */
 	if (!(argp->flags & ISOFSMNT_NORRIP)) {
 		struct iso_directory_record *rootp;
@@ -483,7 +490,8 @@ iso_mountfs(struct vnode *devvp, struct mount *mp, struct lwp *l,
 		bp = NULL;
 	}
 	isomp->im_flags = argp->flags & (ISOFSMNT_NORRIP | ISOFSMNT_GENS |
-		 ISOFSMNT_EXTATT | ISOFSMNT_NOJOLIET | ISOFSMNT_RRCASEINS);
+		 ISOFSMNT_EXTATT | ISOFSMNT_NOJOLIET | ISOFSMNT_RRCASEINS |
+		 ISOFSMNT_UID | ISOFSMNT_GID);
 
 	if (isomp->im_flags & ISOFSMNT_GENS)
 		isomp->iso_ftype = ISO_FTYPE_9660;

--- a/sys/fs/cd9660/cd9660_vnops.c
+++ b/sys/fs/cd9660/cd9660_vnops.c
@@ -61,6 +61,7 @@ __KERNEL_RCSID(0, "$NetBSD: cd9660_vnops.c,v 1.62 2022/03/27 17:10:55 christos E
 #include <fs/cd9660/iso.h>
 #include <fs/cd9660/cd9660_extern.h>
 #include <fs/cd9660/cd9660_node.h>
+#include <fs/cd9660/cd9660_mount.h>
 #include <fs/cd9660/iso_rrip.h>
 #include <fs/cd9660/cd9660_mount.h>
 
@@ -116,11 +117,22 @@ static int
 cd9660_check_permitted(struct vnode *vp, struct iso_node *ip, accmode_t accmode,
     kauth_cred_t cred)
 {
+	accmode_t file_mode;
+	uid_t uid;
+	gid_t gid;
+
+	file_mode = ip->inode.iso_mode & ALLPERMS;
+	file_mode &= (vp->v_type == VDIR) ? ip->i_mnt->im_dmask : ip->i_mnt->im_fmask;
+
+	uid = (ip->i_mnt->im_flags & ISOFSMNT_UID) ?
+	    ip->i_mnt->im_uid : ip->inode.iso_uid;
+	gid = (ip->i_mnt->im_flags & ISOFSMNT_GID) ?
+	    ip->i_mnt->im_gid : ip->inode.iso_gid;
 
 	return kauth_authorize_vnode(cred, KAUTH_ACCESS_ACTION(accmode,
-	    vp->v_type, ip->inode.iso_mode & ALLPERMS), vp, NULL,
-	    genfs_can_access(vp, cred, ip->inode.iso_uid, ip->inode.iso_gid,
-	    ip->inode.iso_mode & ALLPERMS, NULL, accmode));
+	    vp->v_type, file_mode), vp, NULL,
+	    genfs_can_access(vp, cred, uid, gid,
+	    file_mode, NULL, accmode));
 }
 
 int
@@ -160,9 +172,12 @@ cd9660_getattr(void *v)
 	vap->va_fileid	= ip->i_number;
 
 	vap->va_mode	= ip->inode.iso_mode & ALLPERMS;
+	vap->va_mode &= (vp->v_type == VDIR) ? ip->i_mnt->im_dmask : ip->i_mnt->im_fmask;
 	vap->va_nlink	= ip->inode.iso_links;
-	vap->va_uid	= ip->inode.iso_uid;
-	vap->va_gid	= ip->inode.iso_gid;
+	vap->va_uid	= (ip->i_mnt->im_flags & ISOFSMNT_UID) ?
+	    ip->i_mnt->im_uid : ip->inode.iso_uid;
+	vap->va_gid	= (ip->i_mnt->im_flags & ISOFSMNT_GID) ?
+	    ip->i_mnt->im_gid : ip->inode.iso_gid;
 	vap->va_atime	= ip->inode.iso_atime;
 	vap->va_mtime	= ip->inode.iso_mtime;
 	vap->va_ctime	= ip->inode.iso_ctime;


### PR DESCRIPTION
This patch adds arbitrary mask, dirmask, uid & gid support to ISO9660 ala MSDOSFS.

How I tested it:

Compile a kernel with `no file-system CD9660` then:

```
sudo cp /usr/src/sys/fs/cd9660/cd9660_mount.h /usr/include/isofs/cd9660/cd9660_mount.h
cd /usr/src/sbin/mount_cd9660
make clean obj depend
make
sudo make install
cd /usr/src/sys/modules/cd9660
make clean obj depend
make
sudo cp cd9660.kmod /stand/amd64/10.0/modules/cd9660/cd9660.kmod
sudo modunload cd9660
sudo vnconfig /dev/vnd0 /path/to/iso.iso
sudo mount_cd9660 -m640 -M750 -Uricardo -G777 /dev/md0 /mnt
```

Similar patch accepted in FreeBSD: https://github.com/freebsd/freebsd-src/pull/982