### PR TITLE
Import monitor tool from DragonflyBSD

### DIFF
--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -18,7 +18,7 @@ SUBDIR= aiomixer apply asa at audio audiocfg \
 	locale locate lock logger login logname look lorder m4 \
 	machine mail make man menuc mesg midiplay midirecord mixerctl \
 	mkcsmapper mkdep mkesdb mkfifo mklocale mktemp mkubootimage \
-	moduli msgc msgs \
+	moduli monitor msgc msgs \
 	nbperf nc netgroup netstat newgrp newsyslog nfsstat nice nl nohup \
 	pagesize passwd paste patch pathchk pkill pmap pr \
 	printenv printf progress pwait pwhash qsubst quota radioctl rdist \

--- a/usr.bin/monitor/Makefile
+++ b/usr.bin/monitor/Makefile
@@ -1,0 +1,3 @@
+PROG=	monitor
+
+.include <bsd.prog.mk>

--- a/usr.bin/monitor/monitor.1
+++ b/usr.bin/monitor/monitor.1
@@ -1,0 +1,69 @@
+.\" Copyright (c) 2008 The DragonFly Project.  All rights reserved.
+.\"
+.\" This code is derived from software contributed to The DragonFly Project
+.\" by Matthew Dillon <dillon@backplane.com>
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\"
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in
+.\"    the documentation and/or other materials provided with the
+.\"    distribution.
+.\" 3. Neither the name of The DragonFly Project nor the names of its
+.\"    contributors may be used to endorse or promote products derived
+.\"    from this software without specific, prior written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+.\" ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+.\" LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+.\" FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+.\" COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING,
+.\" BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+.\" LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+.\" AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+.\" OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+.\" OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+.\" SUCH DAMAGE.
+.\"
+.Dd October 16, 2008
+.Dt MONITOR 1
+.Os
+.Sh NAME
+.Nm monitor
+.Nd File and directory monitoring utility
+.Sh SYNOPSIS
+.Nm
+.Op Fl qvx
+.Ar
+.Sh DESCRIPTION
+The
+.Nm
+utility monitors one or more files or directories and outputs the
+appropriate file name to stdout whenever a change occurs.
+Supported options are as follows:
+.Bl -tag -width indent
+.It Fl q
+Be more quiet.
+Specifying this option will cause only the file paths to be output.
+.It Fl v
+Be more verbose.
+.It Fl x
+Exit after first hit.
+.Nm
+will exit after reporting the first event.
+.El
+.\".Sh EXAMPLES
+.\".Sh SEE ALSO
+.Sh HISTORY
+The
+.Nm
+utility first appeared in
+.Dx 2.1 and was ported to
+.Nx 11.0 .
+.Sh AUTHORS
+.An Matthew Dillon Aq Mt dillon@backplane.com

--- a/usr.bin/monitor/monitor.1
+++ b/usr.bin/monitor/monitor.1
@@ -1,3 +1,4 @@
+.\"	$NetBSD$
 .\" Copyright (c) 2008 The DragonFly Project.  All rights reserved.
 .\"
 .\" This code is derived from software contributed to The DragonFly Project

--- a/usr.bin/monitor/monitor.c
+++ b/usr.bin/monitor/monitor.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2008 The DragonFly Project.  All rights reserved.
+ *
+ * This code is derived from software contributed to The DragonFly Project
+ * by Matthew Dillon <dillon@backplane.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name of The DragonFly Project nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific, prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#include <sys/types.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <fcntl.h>
+
+typedef struct monitor_elm {
+	const char *path;
+	int	fd;
+} *monitor_elm_t;
+
+static void usage(int exit_code);
+static void monitor_add(const char *path);
+static void monitor_events(void);
+
+static int VerboseOpt;
+static int QuietOpt;
+static int ExitOpt;
+static int KQueueFd;
+static int NumFiles;
+static int MaxFiles;
+static monitor_elm_t *Elms;
+
+int
+main(int ac, char **av)
+{
+	int ch;
+	int i;
+
+	while ((ch = getopt(ac, av, "qvx")) != -1) {
+		switch (ch) {
+		case 'q':
+			if (VerboseOpt > 0)
+				--VerboseOpt;
+			else
+				++QuietOpt;
+			break;
+		case 'v':
+			if (QuietOpt > 0)
+				--QuietOpt;
+			else
+				++VerboseOpt;
+			break;
+		case 'x':
+			ExitOpt = 1;
+			break;
+		default:
+			usage(1);
+			/* not reached */
+		}
+	}
+	ac -= optind;
+	av += optind;
+
+	if (ac < 1) {
+		usage(1);
+		/* not reached */
+	}
+
+	if ((KQueueFd = kqueue()) < 0) {
+		perror("kqueue");
+		exit(1);
+	}
+	NumFiles = MaxFiles = 16;
+	Elms = calloc(MaxFiles, sizeof(monitor_elm_t));
+
+	for (i = 0; i < ac; ++i) {
+		monitor_add(av[i]);
+	}
+	fflush(stdout);
+	do {
+		monitor_events();
+		fflush(stdout);
+	} while (ExitOpt == 0);
+	exit(0);
+}
+
+static
+void
+monitor_add(const char *path)
+{
+	monitor_elm_t elm;
+	struct kevent kev;
+	int n;
+
+	elm = malloc(sizeof(*elm));
+	bzero(elm, sizeof(*elm));
+	elm->path = path;
+	elm->fd = open(path, O_RDONLY);
+	if (elm->fd < 0) {
+		printf("%s\tnot found\n", path);
+		return;
+	}
+	EV_SET(&kev, elm->fd, EVFILT_VNODE, EV_ADD | EV_ENABLE | EV_CLEAR,
+		NOTE_DELETE | NOTE_WRITE | NOTE_EXTEND | NOTE_ATTRIB |
+		NOTE_LINK | NOTE_RENAME | NOTE_REVOKE |
+		NOTE_OPEN | NOTE_CLOSE | NOTE_CLOSE_WRITE | NOTE_READ,
+		0, NULL);
+	n = kevent(KQueueFd, &kev, 1, NULL, 0, NULL);
+	if (n < 0) {
+		perror("kqueue");
+		exit(1);
+	}
+
+	if (elm->fd >= NumFiles) {
+		MaxFiles = (elm->fd + 16) * 3 / 2;
+		Elms = realloc(Elms, MaxFiles * sizeof(elm));
+		bzero(&Elms[NumFiles], (MaxFiles - NumFiles) * sizeof(elm));
+		NumFiles = MaxFiles;
+	}
+	Elms[elm->fd] = elm;
+}
+
+static
+void
+monitor_events(void)
+{
+	struct kevent kev_array[1];
+	struct kevent *kev;
+	monitor_elm_t elm;
+	struct stat st;
+	int bno;
+	int i;
+	int n;
+
+	n = kevent(KQueueFd, NULL, 0, kev_array, 1, NULL);
+	for (i = 0; i < n; ++i) {
+		kev = &kev_array[i];
+		elm = Elms[kev->ident];
+		printf("%-23s", elm->path);
+		if (VerboseOpt && fstat(kev->ident, &st) == 0 &&
+		    S_ISREG(st.st_mode)) {
+			printf(" %10jd", (intmax_t)st.st_size);
+		}
+		while (QuietOpt == 0 && (bno = ffs(kev->fflags)) > 0) {
+			printf(" ");
+			--bno;
+			kev->fflags &= ~(1 << bno);
+			switch (1 << bno) {
+			case NOTE_DELETE:
+				printf("delete");
+				break;
+			case NOTE_WRITE:
+				printf("write");
+				break;
+			case NOTE_EXTEND:
+				printf("extend");
+				break;
+			case NOTE_ATTRIB:
+				printf("attrib");
+				break;
+			case NOTE_LINK:
+				printf("link");
+				break;
+			case NOTE_RENAME:
+				printf("rename");
+				break;
+			case NOTE_REVOKE:
+				printf("revoke");
+				break;
+			case NOTE_OPEN:
+				printf("open");
+				break;
+			case NOTE_CLOSE:
+				printf("close");
+				break;
+			case NOTE_CLOSE_WRITE:
+				printf("closew");
+				break;
+			case NOTE_READ:
+				printf("read");
+				break;
+			default:
+				printf("%08x", 1 << bno);
+				break;
+			}
+		}
+		printf("\n");
+	}
+}
+
+static
+void
+usage(int exit_code)
+{
+	fprintf(stderr,
+		"monitor [-vx] files...\n"
+		"    -q      Be more quiet\n"
+		"    -v      Be more verbose\n"
+		"    -x      Exit after first event reported\n"
+	);
+	exit(exit_code);
+}
+

--- a/usr.bin/monitor/monitor.c
+++ b/usr.bin/monitor/monitor.c
@@ -48,6 +48,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <err.h>
+#include <vis.h>
 
 struct monitor_elm {
 	const char *path;
@@ -152,11 +153,17 @@ monitor_events(void)
 	int bno;
 	int i;
 	int n;
+	char *vispath;
+
+	vispath = malloc(PATH_MAX * 4 + 1);
+	if (vispath == NULL)
+		err(1, "malloc");
 
 	n = kevent(KQueueFd, NULL, 0, kev_array, 1, NULL);
 	for (i = 0; i < n; ++i) {
 		kev = &kev_array[i];
-		printf("%-23s", Elms[kev->ident].path);
+		(void) strvis(vispath, Elms[kev->ident].path, VIS_TAB | VIS_NL | VIS_CSTYLE);
+		printf("%-23s", vispath);
 		if (VerboseOpt && fstat(kev->ident, &st) == 0 &&
 		    S_ISREG(st.st_mode)) {
 			printf(" %10jd", (intmax_t)st.st_size);


### PR DESCRIPTION
- Import [monitor](https://leaf.dragonflybsd.org/cgi/web-man?command=monitor&section=ANY) tool from DragonflyBSD.
- Add support for NOTE_OPEN, NOTE_CLOSE, NOTE_CLOSE_WRITE & NOTE_READ supported by FreeBSD & NetBSD 10.
- Add support for NOTE_TRUNCATE supported by OpenBSD.

Also trying with FreeBSD: https://github.com/freebsd/freebsd-src/pull/1087