### PR TITLE
umount: Add -d option to detach vnd devices

### DIFF
--- a/sbin/umount/umount.8
+++ b/sbin/umount/umount.8
@@ -29,7 +29,7 @@
 .\"
 .\"     @(#)umount.8	8.2 (Berkeley) 5/8/95
 .\"
-.Dd September 12, 2016
+.Dd February 3, 2024
 .Dt UMOUNT 8
 .Os
 .Sh NAME
@@ -37,12 +37,12 @@
 .Nd unmount file systems
 .Sh SYNOPSIS
 .Nm
-.Op Fl fvFR
+.Op Fl dfvFR
 .Op Fl t Ar fstypelist
 .Ar special | node
 .Nm
 .Fl a
-.Op Fl fvF
+.Op Fl dfvF
 .Op Fl h Ar host
 .Op Fl t Ar fstypelist
 .Sh DESCRIPTION
@@ -83,6 +83,11 @@ The options are as follows:
 .Bl -tag -width indent
 .It Fl a
 All the currently mounted file systems except the root are unmounted.
+.It Fl d
+If the filesystem is mounted on an
+.Xr vnd 4
+device (a vnode disk), detach it after
+.Xr unmount 2 .
 .It Fl f
 The file system is forcibly unmounted.
 Active special devices continue to work,
@@ -165,7 +170,8 @@ file system table
 .Sh SEE ALSO
 .Xr unmount 2 ,
 .Xr fstab 5 ,
-.Xr mount 8
+.Xr mount 8 ,
+.Xr vndconfig 8
 .Sh HISTORY
 A
 .Nm


### PR DESCRIPTION
Add a -d option to umount(8) to detach a vnode device. A similar option exists in Linux's umount(8) and also FreeBSD:

https://github.com/freebsd/freebsd-src/pull/972

Ref:  bin/57903