### PR TITLE
ntfs: Mask file permissions we get from mount_ntfs -m option

### DIFF
--- a/sys/fs/ntfs/ntfs_vfsops.c
+++ b/sys/fs/ntfs/ntfs_vfsops.c
@@ -366,7 +366,7 @@ ntfs_mountfs(struct vnode *devvp, struct mount *mp, struct ntfs_args *argsp, str
 	ntmp->ntm_devvp = devvp;
 	ntmp->ntm_uid = argsp->uid;
 	ntmp->ntm_gid = argsp->gid;
-	ntmp->ntm_mode = argsp->mode;
+	ntmp->ntm_mode = argsp->mode & 0777;
 	ntmp->ntm_flag = argsp->flag;
 	mp->mnt_data = ntmp;
 


### PR DESCRIPTION
The ntfs code accepts any value passed from the -m option to `mount_ntfs`.

To reproduce:

```
$ mkntfs -fF ~/ntfs.img
$ sudo vnconfig vnd0 ~/ntfs.img
$ sudo mount_ntfs -m 010555 /dev/vnd0 /mnt
$ ls -l /mnt 
?r-xr-xr-x  1 root  wheel  0 Feb  3 23:15 /mnt
```

Bug fixed in FreeBSD:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=114856
