### PR TITLE
swapon: Do not overwrite Linux swap header

### DIFF
--- a/sbin/swapctl/Makefile
+++ b/sbin/swapctl/Makefile
@@ -1,7 +1,7 @@
 #	$NetBSD: Makefile,v 1.5 2006/08/27 21:07:39 martin Exp $
 
 PROG=	swapctl
-SRCS=	swapctl.c swaplist.c
+SRCS=	swapctl.c swaplist.c swaplinux.c
 MAN=	swapctl.8
 LDADD+=	-lutil
 DPADD+=	${LIBUTIL}

--- a/sbin/swapctl/swapctl.c
+++ b/sbin/swapctl/swapctl.c
@@ -473,6 +473,13 @@ add_swap(char *path, int priority)
 	if (nflag)
 		return 1;
 
+	if (is_linux_swap(spec)) {
+		char *wd = add_wedge_linux_swap(spec);
+		if (wd == NULL)
+			goto oops;
+		spec = wd;
+	}
+
 	if (swapctl(SWAP_ON, spec, priority) < 0) {
 oops:
 		warn("%s", path);
@@ -500,6 +507,10 @@ delete_swap(char *path)
 		return 1;
 
 	if (swapctl(SWAP_OFF, spec, pri) < 0) {
+		warn("%s", path);
+		return 0;
+	}
+	if (del_wedge_linux_swap(spec) < 0) {
 		warn("%s", path);
 		return 0;
 	}

--- a/sbin/swapctl/swapctl.h
+++ b/sbin/swapctl/swapctl.h
@@ -28,3 +28,6 @@
 
 /* pri, kflag, pflag, tflag, dolong (1 for long, 0 for short) */
 int list_swap(int, int, int, int, int, int);
+int is_linux_swap(const char *);
+char *add_wedge_linux_swap(const char *);
+int del_wedge_linux_swap(const char *);

--- a/sbin/swapctl/swaplinux.c
+++ b/sbin/swapctl/swaplinux.c
@@ -1,0 +1,169 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/disk.h>
+#include <sys/disklabel.h>
+#include <sys/dkio.h>
+
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <paths.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "swapctl.h"
+
+/*
+ * Definitions and structure taken from
+ * https://github.com/util-linux/util-linux/blob/master/include/swapheader.h
+ */
+
+#define SWAP_VERSION 1
+#define SWAP_UUID_LENGTH 16
+#define SWAP_LABEL_LENGTH 16
+#define SWAP_SIGNATURE "SWAPSPACE2"
+#define SWAP_SIGNATURE_SZ (sizeof(SWAP_SIGNATURE) - 1)
+
+struct swap_header_v1_2 {
+	char	      bootbits[1024];    /* Space for disklabel etc. */
+	uint32_t      version;
+	uint32_t      last_page;
+	uint32_t      nr_badpages;
+	unsigned char uuid[SWAP_UUID_LENGTH];
+	char	      volume_name[SWAP_LABEL_LENGTH];
+	uint32_t      padding[117];
+	uint32_t      badpages[1];
+};
+
+typedef union {
+	struct swap_header_v1_2 header;
+	struct {
+		uint8_t	reserved[4096 - SWAP_SIGNATURE_SZ];
+		char	signature[SWAP_SIGNATURE_SZ];
+	} tail;
+} swhdr_t;
+
+#define sw_version	header.version
+#define sw_volume_name	header.volume_name
+#define sw_signature	tail.signature
+
+int
+is_linux_swap(const char *name)
+{
+	uint8_t buf[4096];
+	swhdr_t *hdr = (swhdr_t *) buf;
+	int fd;
+
+	fd = open(name, O_RDONLY);
+	if (fd == -1)
+		return (-1);
+
+	if (read(fd, buf, 4096) != 4096) {
+		close(fd);
+		return (-1);
+	}
+	close(fd);
+
+	return (hdr->sw_version == SWAP_VERSION &&
+	    !memcmp(hdr->sw_signature, SWAP_SIGNATURE, SWAP_SIGNATURE_SZ));
+}
+
+char *
+add_wedge_linux_swap(const char *dev)
+{
+	size_t len = strlen(dev);
+	struct dkwedge_info dkw;
+	struct disklabel label;
+	char disk[PATH_MAX];
+	char ch;
+	int fd;
+
+	strlcpy(disk, dev, sizeof(disk));
+
+	ch = disk[len-1];
+	disk[len-1] = '\0';
+
+	fd = open(disk, O_RDWR);
+	if (fd == -1) {
+		warn("%s: open", disk);
+		return (NULL);
+	}
+
+	if (ioctl(fd, DIOCGDINFO, &label) == -1) {
+		warn("%s: ioctl DIOCGDINFO", dev);
+		goto bad;
+	}
+
+	struct partition *part = &label.d_partitions[ch - 'a'];
+
+	if (part->p_fstype != FS_SWAP) {
+		errno = EINVAL;
+		goto bad;
+	}
+
+	(void) strlcpy((char *)dkw.dkw_wname, dev, sizeof(dkw.dkw_wname));
+	(void) strlcpy(dkw.dkw_ptype, "swap", sizeof(dkw.dkw_ptype));
+	/* Skip 8*512 bytes of header */
+	dkw.dkw_offset = part->p_offset + 8;
+	dkw.dkw_size = part->p_size - 8;
+
+	if (ioctl(fd, DIOCAWEDGE, &dkw) == -1) {
+		warn("%s: ioctl DIOCAWEDGE", dev);
+		goto bad;
+	}
+
+	(void) close(fd);
+	(void) snprintf(disk, sizeof(disk), "%s%s", _PATH_DEV, dkw.dkw_devname);
+	return (strdup(disk));
+
+bad:
+	(void) close(fd);
+	return (NULL);
+}
+
+int
+del_wedge_linux_swap(const char *dev) {
+	struct dkwedge_info dkw;
+	char disk[PATH_MAX];
+	int fd;
+
+	if (strncmp(dev, "/dev/dk", strlen("/dev/dk")))
+		return (0);
+
+	fd = open(dev, O_RDWR);
+	if (fd == -1) {
+		warn("%s: open", dev);
+		return (-1);
+	}
+
+	if (ioctl(fd, DIOCGWEDGEINFO, &dkw) == -1) {
+		warn("%s: ioctl DIOCGWEDGEINFO,", dev);
+		goto bad2;
+	}
+	(void) close(fd);
+
+	(void) snprintf(disk, sizeof(disk), "%sr%s", _PATH_DEV, dkw.dkw_parent);
+	fd = open(disk, O_RDWR);
+	if (fd == -1) {
+		warn("%s: open", disk);
+		return (-1);
+	}
+
+	if (ioctl(fd, DIOCDWEDGE, &dkw) == -1) {
+		warn("%s: ioctl DIOCDWEDGE", dev);
+		goto bad2;
+	}
+
+	(void) close(fd);
+	return (0);
+
+bad2:
+	(void) close(fd);
+	return (-1);
+}


### PR DESCRIPTION
The Linux swap partition uses a 4096-byte header that holds the label & UUID. You can see the structure [here](https://github.com/util-linux/util-linux/blob/master/include/swapheader.h). 

The problem is thus how to prevent NetBSD from overwriting the header. It turns out it can be done with [wedge disks](https://man.netbsd.org/dk.4).

This PR modifies **swapon** to automate this process. This will benefit dual-boot installations and also live-CD's.

Doing it in the command line is not straight-forward as in [FreeBSD](https://github.com/freebsd/freebsd-src/pull/1084), but it can be done like this:

```
# Calculate the offset and size of the swap partition and add/substract 8
# (which means 8 512-bytes blocks) from offset and size to dkctl.
sudo dkctl wd1 addwedge mylinuxswap 2056 2095096 swap 
sudo swapon /dev/dk2
swapctl -l
sudo swapctl -d /dev/dk2
sudo dkctl wd1 delwedge dk2
```

With this patch it can be done like this:

```
sudo swapon /dev/wd1e
sudo swapctl -d /dev/dk2
```

TODO:
- Use the same path for the above commands.
- Recognize label so the path with the label is added to /dev/?  It was easy in [FreeBSD](https://github.com/freebsd/freebsd-src/pull/1083) but I don't if it's possible in NetBSD.