### PR TITLE
procfs: Support sysvipc/{msg,sem,shm} used by linux

### DIFF
--- a/sys/miscfs/procfs/procfs.h
+++ b/sys/miscfs/procfs/procfs.h
@@ -111,7 +111,11 @@ typedef enum {
 	PFSstat,	/* process status (if -o linux) */
 	PFSstatm,	/* process memory info (if -o linux) */
 	PFSstatus,	/* process status */
-	PFStask,	/* task subdirector (if -o linux) */
+	PFSsysvipc,	/* sysvipc subdirectory (if -o linux) */
+	PFSsysvipc_msg,	/* sysvipc msg info (if -o linux) */
+	PFSsysvipc_sem,	/* sysvipc sem info (if -o linux) */
+	PFSsysvipc_shm,	/* sysvipc shm info (if -o linux) */
+	PFStask,	/* task subdirectory (if -o linux) */
 	PFSuptime,	/* elapsed time since (if -o linux) */
 	PFSversion,	/* kernel version (if -o linux) */
 #ifdef __HAVE_PROCFS_MACHDEP
@@ -268,6 +272,12 @@ int procfs_doversion(struct lwp *, struct proc *, struct pfsnode *,
 int procfs_doauxv(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);
 int procfs_dolimit(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_dosysvipc_msg(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_dosysvipc_sem(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_dosysvipc_shm(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);
 
 void procfs_hashrem(struct pfsnode *);

--- a/sys/miscfs/procfs/procfs_subr.c
+++ b/sys/miscfs/procfs/procfs_subr.c
@@ -283,6 +283,18 @@ procfs_rw(void *v)
 		error = procfs_doauxv(curl, p, pfs, uio);
 		break;
 
+	case PFSsysvipc_msg:
+		error = procfs_dosysvipc_msg(curl, p, pfs, uio);
+		break;
+
+	case PFSsysvipc_sem:
+		error = procfs_dosysvipc_sem(curl, p, pfs, uio);
+		break;
+
+	case PFSsysvipc_shm:
+		error = procfs_dosysvipc_shm(curl, p, pfs, uio);
+		break;
+
 #ifdef __HAVE_PROCFS_MACHDEP
 	PROCFS_MACHDEP_NODETYPE_CASES
 		error = procfs_machdep_rw(curl, l, pfs, uio);

--- a/sys/miscfs/procfs/procfs_vfsops.c
+++ b/sys/miscfs/procfs/procfs_vfsops.c
@@ -436,6 +436,21 @@ procfs_loadvnode(struct mount *mp, struct vnode *vp,
 		vp->v_type = VREG;
 		break;
 
+	case PFSsysvipc:/* /proc/sysvipc = dr-xr-xr-x */
+		if (pfs->pfs_fd == -1) {
+			pfs->pfs_mode = S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP|
+			    S_IROTH|S_IXOTH;
+			vp->v_type = VDIR;
+			break;
+		}
+		/*FALLTHROUGH*/
+	case PFSsysvipc_msg:	/* /proc/sysvipc/msg = -r--r--r-- */
+	case PFSsysvipc_sem:	/* /proc/sysvipc/sem = -r--r--r-- */
+	case PFSsysvipc_shm:	/* /proc/sysvipc/shm = -r--r--r-- */
+		pfs->pfs_mode = S_IRUSR|S_IRGRP|S_IROTH;
+		vp->v_type = VREG;
+		break;
+
 #ifdef __HAVE_PROCFS_MACHDEP
 	PROCFS_MACHDEP_NODETYPE_CASES
 		procfs_machdep_allocvp(vp);

--- a/sys/miscfs/procfs/procfs_vnops.c
+++ b/sys/miscfs/procfs/procfs_vnops.c
@@ -202,10 +202,27 @@ static const struct proc_target proc_root_targets[] = {
 	{ DT_REG, N("stat"),	    PFScpustat,        procfs_validfile_linux },
 	{ DT_REG, N("loadavg"),	    PFSloadavg,        procfs_validfile_linux },
 	{ DT_REG, N("version"),     PFSversion,        procfs_validfile_linux },
+	{ DT_DIR, N("sysvipc"),     PFSsysvipc,        procfs_validfile_linux },
 #undef N
 };
 static const int nproc_root_targets =
     sizeof(proc_root_targets) / sizeof(proc_root_targets[0]);
+
+/*
+ * List of files in the sysvipc directory
+ */
+static const struct proc_target proc_sysvipc_targets[] = {
+#define N(s) sizeof(s)-1, s
+        /*        name              type            validp */
+	{ DT_DIR, N("."),	PFSsysvipc,	NULL },
+	{ DT_DIR, N(".."),	PFSroot,	NULL },
+	{ DT_REG, N("msg"),	PFSsysvipc_msg, procfs_validfile_linux },
+	{ DT_REG, N("sem"),	PFSsysvipc_sem, procfs_validfile_linux },
+	{ DT_REG, N("shm"),	PFSsysvipc_shm, procfs_validfile_linux },
+#undef N
+};
+static const int nproc_sysvipc_targets =
+    sizeof(proc_sysvipc_targets) / sizeof(proc_sysvipc_targets[0]);
 
 int	procfs_lookup(void *);
 int	procfs_open(void *);
@@ -723,7 +740,15 @@ procfs_getattr(void *v)
 	case PFSself:
 	case PFScurproc:
 	case PFSroot:
+	case PFSsysvipc_msg:
+	case PFSsysvipc_sem:
+	case PFSsysvipc_shm:
 		vap->va_nlink = 1;
+		vap->va_uid = vap->va_gid = 0;
+		break;
+
+	case PFSsysvipc:
+		vap->va_nlink = 5;
 		vap->va_uid = vap->va_gid = 0;
 		break;
 
@@ -841,6 +866,10 @@ procfs_getattr(void *v)
 	case PFSloadavg:
 	case PFSstatm:
 	case PFSversion:
+	case PFSsysvipc:
+	case PFSsysvipc_msg:
+	case PFSsysvipc_sem:
+	case PFSsysvipc_shm:
 		vap->va_bytes = vap->va_size = 0;
 		break;
 	case PFSlimit:
@@ -1156,6 +1185,34 @@ procfs_lookup(void *v)
 		procfs_proc_unlock(p);
 		return error;
 	}
+	case PFSsysvipc:
+		if (cnp->cn_flags & ISDOTDOT) {
+			error = procfs_allocvp(dvp->v_mount, vpp, 0, PFSroot,
+			    -1);
+			return (error);
+		}
+
+		for (i = 0; i < nproc_sysvipc_targets; i++) {
+			pt = &proc_sysvipc_targets[i];
+			/*
+			 * check for node match.  proc is always NULL here,
+			 * so call pt_valid with constant NULL lwp.
+			 */
+			if (cnp->cn_namelen == pt->pt_namlen &&
+			    memcmp(pt->pt_name, pname, cnp->cn_namelen) == 0 &&
+			    (pt->pt_valid == NULL ||
+			     (*pt->pt_valid)(NULL, dvp->v_mount)))
+				break;
+		}
+
+		if (i != nproc_sysvipc_targets) {
+			error = procfs_allocvp(dvp->v_mount, vpp, 0,
+			    pt->pt_pfstype, -1);
+			return (error);
+		}
+
+		return (ENOENT);
+
 	default:
 		return (ENOTDIR);
 	}
@@ -1438,6 +1495,40 @@ procfs_readdir(void *v)
 				*cookies++ = i + 1;
 			nc++;
 		}
+		goto out;
+	}
+
+	/*
+	 * sysvipc subdirectory
+	 */
+	case PFSsysvipc: {
+		if ((error = procfs_proc_lock(vp->v_mount, pfs->pfs_pid, &p,
+					      ESRCH)) != 0)
+			return error;
+		if (ap->a_ncookies) {
+			ncookies = uimin(ncookies, (nproc_sysvipc_targets - i));
+			cookies = malloc(ncookies * sizeof (off_t),
+			    M_TEMP, M_WAITOK);
+			*ap->a_cookies = cookies;
+		}
+
+		for (pt = &proc_sysvipc_targets[i];
+		     uio->uio_resid >= UIO_MX && i < nproc_sysvipc_targets; pt++, i++) {
+			if (pt->pt_valid &&
+			    (*pt->pt_valid)(NULL, vp->v_mount) == 0)
+				continue;
+			d.d_fileno = PROCFS_FILENO(pfs->pfs_pid,
+			    pt->pt_pfstype, -1);
+			d.d_namlen = pt->pt_namlen;
+			memcpy(d.d_name, pt->pt_name, pt->pt_namlen + 1);
+			d.d_type = pt->pt_type;
+
+			if ((error = uiomove(&d, UIO_MX, uio)) != 0)
+				break;
+			if (cookies)
+				*cookies++ = i + 1;
+		}
+
 		goto out;
 	}
 


### PR DESCRIPTION
Add support for proc/sysvipc/{msg,sem,shm}

Ref: kern/58227

To build:

1. `cd /usr/src/sys/modules/procfs`
1. `make && doas cp -f procfs.kmod /stand/$(uname -m)/$(uname -r)/modules/procfs/procfs.kmod`
1. `doas umount -a -t procfs`
1. `doas modunload procfs`
1. `doas modload procfs`
1. `doas mount_procfs -o linux procfs /emul/linux/proc`

How I tested it (needs `ipcmk` from `util-linux`):

```
$ ./ipcmk -M 1k -S 2 -Q
Shared memory id: 196608
Message queue id: 131072
Semaphore id: 131072

$ doas chroot /emul/linux cat /proc/sysvipc/shm
       key      shmid perms                  size  cpid  lpid nattch   uid   gid  cuid  cgid      atime      dtime      ctime                   rss                  swap
-2095488851     196608  4644                  1024  8269     0      0  1000   100  1000   100          0          0 1714979389                     0                     0

$ doas chroot /emul/linux cat /proc/sysvipc/sem
       key      semid perms      nsems   uid   gid  cuid  cgid      otime      ctime
 236286385     131072  1644          2  1000   100  1000   100          0 1714979389

$ doas chroot /emul/linux cat /proc/sysvipc/msg
       key      msqid perms      cbytes       qnum lspid lrpid   uid   gid  cuid  cgid      stime      rtime      ctime
1280589690     131072   644           0          0     0     0  1000   100  1000   100          0          0 1714979389

$ ipcs -a
IPC status from <running system> as of Mon May  6 09:17:22 2024

Message Queues:
T        ID     KEY        MODE       OWNER    GROUP  CREATOR   CGROUP CBYTES  QNUM QBYTES LSPID LRPID    STIME    RTIME    CTIME
q    131072 1280589690 --rw-r--r--  ricardo    users  ricardo    users      0     0   2048     0     0 no-entry no-entry  9:09:49

Shared Memory:
T        ID     KEY        MODE       OWNER    GROUP  CREATOR   CGROUP NATTCH   SEGSZ  CPID  LPID    ATIME    DTIME    CTIME
m    196608 -2466763276837887827 --rw-r--r--  ricardo    users  ricardo    users      0    1024  8269     0 no-entry no-entry  9:09:49

Semaphores:
T        ID     KEY        MODE       OWNER    GROUP  CREATOR   CGROUP NSEMS    OTIME    CTIME
s    131072  236286385 --rw-r--r--  ricardo    users  ricardo    users     2 no-entry  9:09:49

```

Format string adapted from:
- shm: https://github.com/torvalds/linux/blob/master/ipc/shm.c#L1857
- sem: https://github.com/torvalds/linux/blob/master/ipc/sem.c#L2468
- msg: https://github.com/torvalds/linux/blob/master/ipc/msg.c#L1349

Missing perhaps: ifdef's around SYSVSHM, et al.