### PR TITLE
procfs: Add support for proc/self/limits as used by Linux

### DIFF
--- a/sys/compat/linux/common/linux_limit.h
+++ b/sys/compat/linux/common/linux_limit.h
@@ -94,6 +94,11 @@ linux_to_bsd_limit(int lim)
 	case LINUX_RLIMIT_AS:
 		return RLIMIT_AS;
 	case LINUX_RLIMIT_LOCKS:
+	case LINUX_RLIMIT_SIGPENDING:
+	case LINUX_RLIMIT_MSGQUEUE:
+	case LINUX_RLIMIT_NICE:
+	case LINUX_RLIMIT_RTPRIO:
+	case LINUX_RLIMIT_RTTIME:
 		return -EOPNOTSUPP;
 	default:
 		return -EINVAL;

--- a/sys/compat/linux/common/linux_misc.h
+++ b/sys/compat/linux/common/linux_misc.h
@@ -94,6 +94,11 @@ struct linux_sysinfo {
 #define	LINUX_RLIMIT_MEMLOCK	8
 #define	LINUX_RLIMIT_AS		9
 #define	LINUX_RLIMIT_LOCKS	10
+#define LINUX_RLIMIT_SIGPENDING	11
+#define LINUX_RLIMIT_MSGQUEUE	12
+#define LINUX_RLIMIT_NICE	13
+#define LINUX_RLIMIT_RTPRIO	14
+#define LINUX_RLIMIT_RTTIME	15
 #ifdef __mips__  /* XXX only mips32. On mips64, it's ~0ul */
 #define	LINUX_RLIM_INFINITY	0x7fffffffUL
 #define	LINUX32_RLIM_INFINITY	0x7fffffffU

--- a/sys/miscfs/procfs/procfs.h
+++ b/sys/miscfs/procfs/procfs.h
@@ -97,6 +97,7 @@ typedef enum {
 	PFSfpregs,	/* the process's FP register set */
 	PFSloadavg,	/* load average (if -o linux) */
 	PFSlimit,	/* resource limits */
+	PFSlimits,	/* resource limits, Linux style (if -o linux) */
 	PFSmap,		/* memory map */
 	PFSmaps,	/* memory map, Linux style (if -o linux) */
 	PFSmem,		/* the process's memory image */
@@ -268,6 +269,8 @@ int procfs_doversion(struct lwp *, struct proc *, struct pfsnode *,
 int procfs_doauxv(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);
 int procfs_dolimit(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_dolimits(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);
 
 void procfs_hashrem(struct pfsnode *);

--- a/sys/miscfs/procfs/procfs_limit.c
+++ b/sys/miscfs/procfs/procfs_limit.c
@@ -32,14 +32,45 @@
 #include <sys/cdefs.h>
 __KERNEL_RCSID(0, "$NetBSD: procfs_limit.c,v 1.4 2020/05/23 23:42:43 ad Exp $");
 
+#if defined(_KERNEL_OPT)
+#include "opt_sysv.h"
+#endif
+
 #include <sys/param.h>
 #include <sys/systm.h>
 #include <sys/proc.h>
 #include <sys/malloc.h>
 #include <sys/resource.h>
 #include <miscfs/procfs/procfs.h>
+#include <compat/linux/common/linux_misc.h>
+#ifdef SYSVMSG
+#include <sys/msg.h>
+#endif
 
-#define MAXBUFFERSIZE (256 * 1024)
+/* Taken from FreeBSD sys/compat/linprocfs/linprocfs.c */
+static const struct linux_rlimit_ident {
+	const char      *desc;
+	const char      *unit;
+	unsigned int    rlim_id;
+} linux_rlimits_ident[] = {
+	{ "Max cpu time",	"seconds",	RLIMIT_CPU },
+	{ "Max file size",	"bytes",	RLIMIT_FSIZE },
+	{ "Max data size",	"bytes",	RLIMIT_DATA },
+	{ "Max stack size",	"bytes",	RLIMIT_STACK },
+	{ "Max core file size",	"bytes",	RLIMIT_CORE },
+	{ "Max resident set",	"bytes",	RLIMIT_RSS },
+	{ "Max processes",	"processes",	RLIMIT_NPROC },
+	{ "Max open files",	"files",	RLIMIT_NOFILE },
+	{ "Max locked memory",	"bytes",	RLIMIT_MEMLOCK },
+	{ "Max address space",	"bytes",	RLIMIT_AS },
+	{ "Max file locks",	"locks",	LINUX_RLIMIT_LOCKS },
+	{ "Max pending signals", "signals",	LINUX_RLIMIT_SIGPENDING },
+	{ "Max msgqueue size",	"bytes",	LINUX_RLIMIT_MSGQUEUE },
+	{ "Max nice priority",	"",		LINUX_RLIMIT_NICE },
+	{ "Max realtime priority", "",		LINUX_RLIMIT_RTPRIO },
+	{ "Max realtime timeout", "us",		LINUX_RLIMIT_RTTIME },
+	{ 0, 0, 0 }
+};
 
 static size_t
 prl(char *buf, size_t len, intmax_t lim, char sep)
@@ -79,6 +110,75 @@ procfs_dolimit(struct lwp *curl, struct proc *p, struct pfsnode *pfs,
 		    label[i]);
 		pos += prl(buffer + pos, bufsize - pos, rl[i].rlim_cur, ' ');
 		pos += prl(buffer + pos, bufsize - pos, rl[i].rlim_max, '\n');
+	}
+
+	if ((uintmax_t)uio->uio_offset < pos)
+		error = uiomove(buffer + uio->uio_offset,
+		    pos - uio->uio_offset, uio);
+	else
+		error = 0;
+
+	if (buffer != NULL)
+		free(buffer, M_TEMP);
+
+	return error;
+}
+
+int
+procfs_dolimits(struct lwp *curl, struct proc *p, struct pfsnode *pfs,
+     struct uio *uio)
+{
+	const struct linux_rlimit_ident *li;
+	int error;
+	char *buffer;
+	size_t bufsize, pos;
+	struct rlimit rl, rlimits[RLIM_NLIMITS];
+
+	if (uio->uio_rw != UIO_READ)
+		return EOPNOTSUPP;
+
+	mutex_enter(&proc_lock);
+	mutex_enter(p->p_lock);
+	memcpy(rlimits, p->p_rlimit, sizeof(rlimits));
+	mutex_exit(p->p_lock);
+	mutex_exit(&proc_lock);
+
+	error = 0;
+
+	bufsize = (64 * 3) * __arraycount(linux_rlimits_ident);
+	buffer = malloc(bufsize, M_TEMP, M_WAITOK);
+	pos = snprintf(buffer, bufsize, "%-26s%-21s%-21s%-21s\n",
+	    "Limit", "Soft Limit", "Hard Limit", "Units");
+	for (li = linux_rlimits_ident; li->desc != NULL; ++li) {
+		switch (li->rlim_id)
+		{
+		case LINUX_RLIMIT_LOCKS:
+		case LINUX_RLIMIT_RTTIME:
+		case LINUX_RLIMIT_SIGPENDING:
+			rl.rlim_cur = RLIM_INFINITY;
+			break;
+		case LINUX_RLIMIT_MSGQUEUE:
+#ifdef SYSVMSG
+			rl.rlim_cur = rl.rlim_max = msginfo.msgmnb;
+			break;
+#endif
+		case LINUX_RLIMIT_NICE:
+		case LINUX_RLIMIT_RTPRIO:
+			rl.rlim_cur = rl.rlim_max = 0;
+			break;
+		default:
+			rl = rlimits[li->rlim_id];
+			break;
+		}
+		if (rl.rlim_cur == RLIM_INFINITY)
+			pos += snprintf(buffer + pos, bufsize - pos,
+			    "%-26s%-21s%-21s%-10s\n",
+			    li->desc, "unlimited", "unlimited", li->unit);
+		else
+			pos += snprintf(buffer + pos, bufsize - pos,
+			    "%-26s%-21llu%-21llu%-10s\n",
+			    li->desc, (unsigned long long)rl.rlim_cur,
+			    (unsigned long long)rl.rlim_max, li->unit);
 	}
 
 	if ((uintmax_t)uio->uio_offset < pos)

--- a/sys/miscfs/procfs/procfs_subr.c
+++ b/sys/miscfs/procfs/procfs_subr.c
@@ -215,6 +215,10 @@ procfs_rw(void *v)
 		error = procfs_dolimit(curl, p, pfs, uio);
 		break;
 
+	case PFSlimits:
+		error = procfs_dolimits(curl, p, pfs, uio);
+		break;
+
 	case PFSmap:
 		error = procfs_domap(curl, p, pfs, uio, 0);
 		break;

--- a/sys/miscfs/procfs/procfs_vfsops.c
+++ b/sys/miscfs/procfs/procfs_vfsops.c
@@ -431,7 +431,8 @@ procfs_loadvnode(struct mount *mp, struct vnode *vp,
 	case PFSloadavg:	/* /proc/loadavg = -r--r--r-- */
 	case PFSstatm:		/* /proc/N/statm = -r--r--r-- */
 	case PFSversion:	/* /proc/version = -r--r--r-- */
-	case PFSlimit:		/* /proc/limit = -r--r--r-- */
+	case PFSlimit:		/* /proc/N/limit = -r--r--r-- */
+	case PFSlimits:		/* /proc/N/limits = -r--r--r-- */
 		pfs->pfs_mode = S_IRUSR|S_IRGRP|S_IROTH;
 		vp->v_type = VREG;
 		break;

--- a/sys/miscfs/procfs/procfs_vnops.c
+++ b/sys/miscfs/procfs/procfs_vnops.c
@@ -171,6 +171,7 @@ static const struct proc_target {
 	{ DT_REG, N("file"),	PFSfile,	procfs_validfile },
 	{ DT_REG, N("fpregs"),	PFSfpregs,	procfs_validfpregs },
 	{ DT_REG, N("limit"),	PFSlimit,	NULL },
+	{ DT_REG, N("limits"),	PFSlimits,	procfs_validfile_linux },
 	{ DT_REG, N("map"),	PFSmap,		procfs_validmap },
 	{ DT_REG, N("maps"),	PFSmaps,	procfs_validmap },
 	{ DT_REG, N("mem"),	PFSmem,		NULL },
@@ -704,6 +705,7 @@ procfs_getattr(void *v)
 	case PFSmap:
 	case PFSmaps:
 	case PFSlimit:
+	case PFSlimits:
 	case PFSauxv:
 		vap->va_nlink = 1;
 		vap->va_uid = kauth_cred_geteuid(procp->p_cred);
@@ -844,6 +846,7 @@ procfs_getattr(void *v)
 		vap->va_bytes = vap->va_size = 0;
 		break;
 	case PFSlimit:
+	case PFSlimits:
 	case PFSmap:
 	case PFSmaps:
 		/*


### PR DESCRIPTION
The first commit adds definitions for missing Linux resource limits constants.

Inspired in the [FreeBSD implementation](https://github.com/freebsd/freebsd-src/blob/main/sys/compat/linprocfs/linprocfs.c#L1864) and NetBSD's own implementation of proc/self/limit.

Ref: kern/58240