### PR TITLE
linux: Support POSIX message queues

### DIFF
--- a/sys/compat/linux/arch/aarch64/linux_syscall.h
+++ b/sys/compat/linux/arch/aarch64/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.10 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -452,6 +452,24 @@
 
 /* syscall: "sysinfo" ret: "int" args: "struct linux_sysinfo *" */
 #define	LINUX_SYS_sysinfo	179
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	180
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	181
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	182
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	183
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	184
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	185
 
 #ifdef SYSVMSG
 /* syscall: "msgget" ret: "int" args: "key_t" "int" */

--- a/sys/compat/linux/arch/aarch64/linux_syscallargs.h
+++ b/sys/compat/linux/arch/aarch64/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.10 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -772,6 +772,50 @@ struct linux_sys_sysinfo_args {
 	syscallarg(struct linux_sysinfo *) arg;
 };
 check_syscall_args(linux_sys_sysinfo)
+
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
 #ifdef SYSVMSG
 
 struct sys_msgget_args;
@@ -1359,6 +1403,18 @@ int	sys_getegid(struct lwp *, const void *, register_t *);
 int	linux_sys_gettid(struct lwp *, const void *, register_t *);
 
 int	linux_sys_sysinfo(struct lwp *, const struct linux_sys_sysinfo_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 #ifdef SYSVMSG
 int	sys_msgget(struct lwp *, const struct sys_msgget_args *, register_t *);

--- a/sys/compat/linux/arch/aarch64/linux_syscalls.c
+++ b/sys/compat/linux/arch/aarch64/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.10 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.10 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #if defined(_KERNEL_OPT)
@@ -34,6 +34,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.10 2023/08/19 17:50:24 christos
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_signal.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #else /* _KERNEL_OPT */
 #include <sys/null.h>
@@ -220,12 +221,12 @@ const char *const linux_syscallnames[] = {
 	/* 177 */	"getegid",
 	/* 178 */	"gettid",
 	/* 179 */	"sysinfo",
-	/* 180 */	"#180 (unimplemented mq_open)",
-	/* 181 */	"#181 (unimplemented mq_unlink)",
-	/* 182 */	"#182 (unimplemented mq_timedsend)",
-	/* 183 */	"#183 (unimplemented mq_timedreceive)",
-	/* 184 */	"#184 (unimplemented mq_notify)",
-	/* 185 */	"#185 (unimplemented mq_getsetattr)",
+	/* 180 */	"mq_open",
+	/* 181 */	"mq_unlink",
+	/* 182 */	"mq_timedsend",
+	/* 183 */	"mq_timedreceive",
+	/* 184 */	"mq_notify",
+	/* 185 */	"mq_getsetattr",
 #ifdef SYSVMSG
 	/* 186 */	"msgget",
 	/* 187 */	"msgctl",
@@ -758,12 +759,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 177 */	NULL, /* getegid */
 	/* 178 */	NULL, /* gettid */
 	/* 179 */	NULL, /* sysinfo */
-	/* 180 */	NULL, /* unimplemented mq_open */
-	/* 181 */	NULL, /* unimplemented mq_unlink */
-	/* 182 */	NULL, /* unimplemented mq_timedsend */
-	/* 183 */	NULL, /* unimplemented mq_timedreceive */
-	/* 184 */	NULL, /* unimplemented mq_notify */
-	/* 185 */	NULL, /* unimplemented mq_getsetattr */
+	/* 180 */	NULL, /* mq_open */
+	/* 181 */	NULL, /* mq_unlink */
+	/* 182 */	NULL, /* mq_timedsend */
+	/* 183 */	NULL, /* mq_timedreceive */
+	/* 184 */	NULL, /* mq_notify */
+	/* 185 */	NULL, /* mq_getsetattr */
 #ifdef SYSVMSG
 	/* 186 */	NULL, /* msgget */
 	/* 187 */	NULL, /* msgctl */

--- a/sys/compat/linux/arch/aarch64/linux_sysent.c
+++ b/sys/compat/linux/arch/aarch64/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.10 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.10 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include "opt_sysv.h"
@@ -33,6 +33,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.10 2023/08/19 17:50:24 christos E
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_signal.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 
 #define	s(type)	sizeof(type)
@@ -812,23 +813,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = (sy_call_t *)linux_sys_sysinfo
 	},		/* 179 = sysinfo */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 180 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 180 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 181 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 181 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 182 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 182 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 183 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 183 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 184 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 184 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 185 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 185 = mq_getsetattr */
 #ifdef SYSVMSG
 	{
 		ns(struct sys_msgget_args),

--- a/sys/compat/linux/arch/aarch64/linux_systrace_args.c
+++ b/sys/compat/linux/arch/aarch64/linux_systrace_args.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_systrace_args.c,v 1.10 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument to DTrace register array conversion.
@@ -1233,6 +1233,62 @@ systrace_args(register_t sysnum, const void *params, uintptr_t *uarg, size_t *n_
 		const struct linux_sys_sysinfo_args *p = params;
 		uarg[0] = (intptr_t) SCARG(p, arg); /* struct linux_sysinfo * */
 		*n_args = 1;
+		break;
+	}
+	/* linux_sys_mq_open */
+	case 180: {
+		const struct linux_sys_mq_open_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		iarg[1] = SCARG(p, oflag); /* int */
+		iarg[2] = SCARG(p, mode); /* linux_umode_t */
+		uarg[3] = (intptr_t) SCARG(p, attr); /* struct linux_mq_attr * */
+		*n_args = 4;
+		break;
+	}
+	/* linux_sys_mq_unlink */
+	case 181: {
+		const struct linux_sys_mq_unlink_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		*n_args = 1;
+		break;
+	}
+	/* linux_sys_mq_timedsend */
+	case 182: {
+		const struct linux_sys_mq_timedsend_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* const char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = SCARG(p, msg_prio); /* unsigned int */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_timedreceive */
+	case 183: {
+		const struct linux_sys_mq_timedreceive_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = (intptr_t) SCARG(p, msg_prio); /* unsigned int * */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_notify */
+	case 184: {
+		const struct linux_sys_mq_notify_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, sevp); /* const struct linux_sigevent * */
+		*n_args = 2;
+		break;
+	}
+	/* linux_sys_mq_getsetattr */
+	case 185: {
+		const struct linux_sys_mq_getsetattr_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, newattr); /* const struct linux_mq_attr * */
+		uarg[2] = (intptr_t) SCARG(p, oldattr); /* struct linux_mq_attr * */
+		*n_args = 3;
 		break;
 	}
 #ifdef SYSVMSG
@@ -3797,6 +3853,108 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
+	/* linux_sys_mq_open */
+	case 180:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		case 1:
+			p = "int";
+			break;
+		case 2:
+			p = "linux_umode_t";
+			break;
+		case 3:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_unlink */
+	case 181:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedsend */
+	case 182:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 183:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int *";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_notify */
+	case 184:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_sigevent *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 185:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_mq_attr *";
+			break;
+		case 2:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
 #ifdef SYSVMSG
 	/* sys_msgget */
 	case 186:
@@ -5415,6 +5573,36 @@ systrace_return_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 	case 178:
 	/* linux_sys_sysinfo */
 	case 179:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_open */
+	case 180:
+		if (ndx == 0 || ndx == 1)
+			p = "linux_mqd_t";
+		break;
+	/* linux_sys_mq_unlink */
+	case 181:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedsend */
+	case 182:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 183:
+		if (ndx == 0 || ndx == 1)
+			p = "ssize_t";
+		break;
+	/* linux_sys_mq_notify */
+	case 184:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 185:
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;

--- a/sys/compat/linux/arch/aarch64/syscalls.master
+++ b/sys/compat/linux/arch/aarch64/syscalls.master
@@ -62,6 +62,7 @@
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_signal.h>
+#include <compat/linux/common/linux_mqueue.h>
 
 #include <compat/linux/linux_syscallargs.h>
 
@@ -359,12 +360,23 @@
 177	NOARGS		{ gid_t|sys||getegid(void); }
 178	STD		{ pid_t|linux_sys||gettid(void); }
 179	STD		{ int|linux_sys||sysinfo(struct linux_sysinfo *arg); }
-180	UNIMPL		mq_open
-181	UNIMPL		mq_unlink
-182	UNIMPL		mq_timedsend
-183	UNIMPL		mq_timedreceive
-184	UNIMPL		mq_notify
-185	UNIMPL		mq_getsetattr
+180	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+181	STD		{ int|linux_sys||mq_unlink(const char *name); }
+182	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+183	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+184	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+185	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 #ifdef SYSVMSG
 186	NOARGS		{ int|sys||msgget(key_t key, int msgflg); }
 187	NOARGS		{ int|linux_sys||msgctl(int msqid, int cmd, \

--- a/sys/compat/linux/arch/alpha/linux_syscall.h
+++ b/sys/compat/linux/arch/alpha/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.119 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -674,6 +674,24 @@
 
 /* syscall: "fstat64" ret: "int" args: "int" "struct linux_stat64 *" */
 #define	LINUX_SYS_fstat64	427
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	432
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	433
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	434
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	435
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	436
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	437
 
 /* syscall: "waitid" ret: "int" args: "int" "id_t" "linux_siginfo_t *" "int" "struct rusage50 *" */
 #define	LINUX_SYS_waitid	438

--- a/sys/compat/linux/arch/alpha/linux_syscallargs.h
+++ b/sys/compat/linux/arch/alpha/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.118 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -1060,6 +1060,50 @@ struct linux_sys_fstat64_args {
 };
 check_syscall_args(linux_sys_fstat64)
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_waitid_args {
 	syscallarg(int) idtype;
 	syscallarg(id_t) id;
@@ -1779,6 +1823,18 @@ int	linux_sys_stat64(struct lwp *, const struct linux_sys_stat64_args *, registe
 int	linux_sys_lstat64(struct lwp *, const struct linux_sys_lstat64_args *, register_t *);
 
 int	linux_sys_fstat64(struct lwp *, const struct linux_sys_fstat64_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_waitid(struct lwp *, const struct linux_sys_waitid_args *, register_t *);
 

--- a/sys/compat/linux/arch/alpha/linux_syscalls.c
+++ b/sys/compat/linux/arch/alpha/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.120 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.120 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #if defined(_KERNEL_OPT)
@@ -28,6 +28,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.120 2023/08/19 17:50:24 christo
 #include <compat/linux/common/linux_sem.h>
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #include <compat/linux/arch/alpha/linux_osf1.h>
 #else /* _KERNEL_OPT */
@@ -491,12 +492,12 @@ const char *const linux_syscallnames[] = {
 	/* 429 */	"#429 (unimplemented mbind)",
 	/* 430 */	"#430 (unimplemented get_mempolicy)",
 	/* 431 */	"#431 (unimplemented set_mempolicy)",
-	/* 432 */	"#432 (unimplemented mq_open)",
-	/* 433 */	"#433 (unimplemented mq_unlink)",
-	/* 434 */	"#434 (unimplemented mq_timedsend)",
-	/* 435 */	"#435 (unimplemented mq_timedreceive)",
-	/* 436 */	"#436 (unimplemented mq_notify)",
-	/* 437 */	"#437 (unimplemented mq_getsetattr)",
+	/* 432 */	"mq_open",
+	/* 433 */	"mq_unlink",
+	/* 434 */	"mq_timedsend",
+	/* 435 */	"mq_timedreceive",
+	/* 436 */	"mq_notify",
+	/* 437 */	"mq_getsetattr",
 	/* 438 */	"waitid",
 	/* 439 */	"#439 (unimplemented add_key)",
 	/* 440 */	"#440 (unimplemented request_key)",
@@ -1544,12 +1545,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 429 */	NULL, /* unimplemented mbind */
 	/* 430 */	NULL, /* unimplemented get_mempolicy */
 	/* 431 */	NULL, /* unimplemented set_mempolicy */
-	/* 432 */	NULL, /* unimplemented mq_open */
-	/* 433 */	NULL, /* unimplemented mq_unlink */
-	/* 434 */	NULL, /* unimplemented mq_timedsend */
-	/* 435 */	NULL, /* unimplemented mq_timedreceive */
-	/* 436 */	NULL, /* unimplemented mq_notify */
-	/* 437 */	NULL, /* unimplemented mq_getsetattr */
+	/* 432 */	NULL, /* mq_open */
+	/* 433 */	NULL, /* mq_unlink */
+	/* 434 */	NULL, /* mq_timedsend */
+	/* 435 */	NULL, /* mq_timedreceive */
+	/* 436 */	NULL, /* mq_notify */
+	/* 437 */	NULL, /* mq_getsetattr */
 	/* 438 */	NULL, /* waitid */
 	/* 439 */	NULL, /* unimplemented add_key */
 	/* 440 */	NULL, /* unimplemented request_key */

--- a/sys/compat/linux/arch/alpha/linux_sysent.c
+++ b/sys/compat/linux/arch/alpha/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.119 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.119 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include "opt_sysv.h"
@@ -27,6 +27,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.119 2023/08/19 17:50:24 christos 
 #include <compat/linux/common/linux_sem.h>
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #include <compat/linux/arch/alpha/linux_osf1.h>
 
@@ -1739,23 +1740,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 431 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 432 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 432 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 433 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 433 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 434 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 434 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 435 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 435 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 436 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 436 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 437 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 437 = mq_getsetattr */
 	{
 		ns(struct linux_sys_waitid_args),
 		.sy_flags = SYCALL_ARG_PTR,

--- a/sys/compat/linux/arch/alpha/syscalls.master
+++ b/sys/compat/linux/arch/alpha/syscalls.master
@@ -75,6 +75,7 @@
 #include <compat/linux/common/linux_sem.h>
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 ;#include <compat/linux/common/linux_machdep.h>
 
 #include <compat/linux/linux_syscallargs.h>
@@ -697,12 +698,23 @@
 429	UNIMPL		mbind
 430	UNIMPL		get_mempolicy
 431	UNIMPL		set_mempolicy
-432	UNIMPL		mq_open
-433	UNIMPL		mq_unlink
-434	UNIMPL		mq_timedsend
-435	UNIMPL		mq_timedreceive
-436	UNIMPL		mq_notify
-437	UNIMPL		mq_getsetattr
+432	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+433	STD		{ int|linux_sys||mq_unlink(const char *name); }
+434	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+435	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+436	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+437	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 438	STD		{ int|linux_sys||waitid(int idtype, id_t id, \
 			    linux_siginfo_t *infop, int options, \
 			    struct rusage50 *rusage); }

--- a/sys/compat/linux/arch/amd64/linux_syscall.h
+++ b/sys/compat/linux/arch/amd64/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.81 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -620,6 +620,24 @@
 
 /* syscall: "utimes" ret: "int" args: "const char *" "const struct timeval50 *" */
 #define	LINUX_SYS_utimes	235
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	240
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	241
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	242
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	243
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	244
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	245
 
 /* syscall: "waitid" ret: "int" args: "int" "id_t" "linux_siginfo_t *" "int" "struct rusage50 *" */
 #define	LINUX_SYS_waitid	247

--- a/sys/compat/linux/arch/amd64/linux_syscallargs.h
+++ b/sys/compat/linux/arch/amd64/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.81 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -950,6 +950,50 @@ check_syscall_args(linux_sys_tgkill)
 
 struct compat_50_sys_utimes_args;
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_waitid_args {
 	syscallarg(int) idtype;
 	syscallarg(id_t) id;
@@ -1642,6 +1686,18 @@ int	linux_sys_epoll_ctl(struct lwp *, const struct linux_sys_epoll_ctl_args *, r
 int	linux_sys_tgkill(struct lwp *, const struct linux_sys_tgkill_args *, register_t *);
 
 int	compat_50_sys_utimes(struct lwp *, const struct compat_50_sys_utimes_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_waitid(struct lwp *, const struct linux_sys_waitid_args *, register_t *);
 

--- a/sys/compat/linux/arch/amd64/linux_syscalls.c
+++ b/sys/compat/linux/arch/amd64/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.81 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.81 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #if defined(_KERNEL_OPT)
@@ -33,6 +33,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.81 2023/08/19 17:50:24 christos
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/linux_syscallargs.h>
 #else /* _KERNEL_OPT */
@@ -307,12 +308,12 @@ const char *const linux_syscallnames[] = {
 	/* 237 */	"#237 (unimplemented mbind)",
 	/* 238 */	"#238 (unimplemented set_mempolicy)",
 	/* 239 */	"#239 (unimplemented get_mempolicy)",
-	/* 240 */	"#240 (unimplemented mq_open)",
-	/* 241 */	"#241 (unimplemented mq_unlink)",
-	/* 242 */	"#242 (unimplemented mq_timedsend)",
-	/* 243 */	"#243 (unimplemented mq_timedreceive)",
-	/* 244 */	"#244 (unimplemented mq_notify)",
-	/* 245 */	"#245 (unimplemented mq_getsetattr)",
+	/* 240 */	"mq_open",
+	/* 241 */	"mq_unlink",
+	/* 242 */	"mq_timedsend",
+	/* 243 */	"mq_timedreceive",
+	/* 244 */	"mq_notify",
+	/* 245 */	"mq_getsetattr",
 	/* 246 */	"#246 (unimplemented kexec_load)",
 	/* 247 */	"waitid",
 	/* 248 */	"#248 (unimplemented add_key)",
@@ -851,12 +852,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 237 */	NULL, /* unimplemented mbind */
 	/* 238 */	NULL, /* unimplemented set_mempolicy */
 	/* 239 */	NULL, /* unimplemented get_mempolicy */
-	/* 240 */	NULL, /* unimplemented mq_open */
-	/* 241 */	NULL, /* unimplemented mq_unlink */
-	/* 242 */	NULL, /* unimplemented mq_timedsend */
-	/* 243 */	NULL, /* unimplemented mq_timedreceive */
-	/* 244 */	NULL, /* unimplemented mq_notify */
-	/* 245 */	NULL, /* unimplemented mq_getsetattr */
+	/* 240 */	NULL, /* mq_open */
+	/* 241 */	NULL, /* mq_unlink */
+	/* 242 */	NULL, /* mq_timedsend */
+	/* 243 */	NULL, /* mq_timedreceive */
+	/* 244 */	NULL, /* mq_notify */
+	/* 245 */	NULL, /* mq_getsetattr */
 	/* 246 */	NULL, /* unimplemented kexec_load */
 	/* 247 */	NULL, /* waitid */
 	/* 248 */	NULL, /* unimplemented add_key */

--- a/sys/compat/linux/arch/amd64/linux_sysent.c
+++ b/sys/compat/linux/arch/amd64/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.81 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.81 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include "opt_sysv.h"
@@ -32,6 +32,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.81 2023/08/19 17:50:24 christos E
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/linux_syscallargs.h>
 
@@ -1126,23 +1127,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 239 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 240 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 240 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 241 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 241 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 242 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 242 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 243 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 243 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 244 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 244 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 245 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 245 = mq_getsetattr */
 	{
 		.sy_call = linux_sys_nosys,
 	},		/* 246 = filler */

--- a/sys/compat/linux/arch/amd64/linux_systrace_args.c
+++ b/sys/compat/linux/arch/amd64/linux_systrace_args.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_systrace_args.c,v 1.25 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument to DTrace register array conversion.
@@ -1652,6 +1652,62 @@ systrace_args(register_t sysnum, const void *params, uintptr_t *uarg, size_t *n_
 		uarg[0] = (intptr_t) SCARG(p, path); /* const char * */
 		uarg[1] = (intptr_t) SCARG(p, tptr); /* const struct timeval50 * */
 		*n_args = 2;
+		break;
+	}
+	/* linux_sys_mq_open */
+	case 240: {
+		const struct linux_sys_mq_open_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		iarg[1] = SCARG(p, oflag); /* int */
+		iarg[2] = SCARG(p, mode); /* linux_umode_t */
+		uarg[3] = (intptr_t) SCARG(p, attr); /* struct linux_mq_attr * */
+		*n_args = 4;
+		break;
+	}
+	/* linux_sys_mq_unlink */
+	case 241: {
+		const struct linux_sys_mq_unlink_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		*n_args = 1;
+		break;
+	}
+	/* linux_sys_mq_timedsend */
+	case 242: {
+		const struct linux_sys_mq_timedsend_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* const char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = SCARG(p, msg_prio); /* unsigned int */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_timedreceive */
+	case 243: {
+		const struct linux_sys_mq_timedreceive_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = (intptr_t) SCARG(p, msg_prio); /* unsigned int * */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_notify */
+	case 244: {
+		const struct linux_sys_mq_notify_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, sevp); /* const struct linux_sigevent * */
+		*n_args = 2;
+		break;
+	}
+	/* linux_sys_mq_getsetattr */
+	case 245: {
+		const struct linux_sys_mq_getsetattr_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, newattr); /* const struct linux_mq_attr * */
+		uarg[2] = (intptr_t) SCARG(p, oldattr); /* struct linux_mq_attr * */
+		*n_args = 3;
 		break;
 	}
 	/* linux_sys_waitid */
@@ -4774,6 +4830,108 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
+	/* linux_sys_mq_open */
+	case 240:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		case 1:
+			p = "int";
+			break;
+		case 2:
+			p = "linux_umode_t";
+			break;
+		case 3:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_unlink */
+	case 241:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedsend */
+	case 242:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 243:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int *";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_notify */
+	case 244:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_sigevent *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 245:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_mq_attr *";
+			break;
+		case 2:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
 	/* linux_sys_waitid */
 	case 247:
 		switch(ndx) {
@@ -6477,6 +6635,36 @@ systrace_return_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 		break;
 	/* compat_50_sys_utimes */
 	case 235:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_open */
+	case 240:
+		if (ndx == 0 || ndx == 1)
+			p = "linux_mqd_t";
+		break;
+	/* linux_sys_mq_unlink */
+	case 241:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedsend */
+	case 242:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 243:
+		if (ndx == 0 || ndx == 1)
+			p = "ssize_t";
+		break;
+	/* linux_sys_mq_notify */
+	case 244:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 245:
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;

--- a/sys/compat/linux/arch/amd64/syscalls.master
+++ b/sys/compat/linux/arch/amd64/syscalls.master
@@ -59,6 +59,7 @@
 #include <compat/linux/common/linux_shm.h>
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/common/linux_machdep.h>
 
 #include <compat/linux/linux_syscallargs.h>
@@ -456,12 +457,23 @@
 237	UNIMPL		mbind
 238	UNIMPL		set_mempolicy
 239	UNIMPL		get_mempolicy
-240	UNIMPL		mq_open
-241	UNIMPL		mq_unlink
-242	UNIMPL		mq_timedsend
-243	UNIMPL		mq_timedreceive
-244	UNIMPL		mq_notify
-245	UNIMPL		mq_getsetattr
+240	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+241	STD		{ int|linux_sys||mq_unlink(const char *name); }
+242	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+243	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+244	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+245	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 246	UNIMPL		kexec_load
 247	STD		{ int|linux_sys||waitid(int idtype, id_t id, \
 			    linux_siginfo_t *infop, int options, \

--- a/sys/compat/linux/arch/arm/linux_syscall.h
+++ b/sys/compat/linux/arch/arm/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.92 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -678,6 +678,24 @@
 
 /* syscall: "fadvise64_64" ret: "int" args: "int" "off_t" "off_t" "int" */
 #define	LINUX_SYS_fadvise64_64	270
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	274
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	275
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	276
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	277
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	278
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	279
 
 /* syscall: "waitid" ret: "int" args: "int" "id_t" "linux_siginfo_t *" "int" "struct rusage50 *" */
 #define	LINUX_SYS_waitid	280

--- a/sys/compat/linux/arch/arm/linux_syscallargs.h
+++ b/sys/compat/linux/arch/arm/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.92 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -1024,6 +1024,50 @@ struct linux_sys_fadvise64_64_args {
 };
 check_syscall_args(linux_sys_fadvise64_64)
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_waitid_args {
 	syscallarg(int) idtype;
 	syscallarg(id_t) id;
@@ -1731,6 +1775,18 @@ int	linux_sys_tgkill(struct lwp *, const struct linux_sys_tgkill_args *, registe
 int	compat_50_sys_utimes(struct lwp *, const struct compat_50_sys_utimes_args *, register_t *);
 
 int	linux_sys_fadvise64_64(struct lwp *, const struct linux_sys_fadvise64_64_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_waitid(struct lwp *, const struct linux_sys_waitid_args *, register_t *);
 

--- a/sys/compat/linux/arch/arm/linux_syscalls.c
+++ b/sys/compat/linux/arch/arm/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.92 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.92 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include <sys/param.h>
@@ -24,6 +24,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.92 2023/08/19 17:50:24 christos
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #else /* _KERNEL_OPT */
 #include <sys/null.h>
@@ -309,12 +310,12 @@ const char *const linux_syscallnames[] = {
 	/* 271 */	"#271 (unimplemented pciconfig_iobase)",
 	/* 272 */	"#272 (unimplemented pciconfig_read)",
 	/* 273 */	"#273 (unimplemented pciconfig_write)",
-	/* 274 */	"#274 (unimplemented mq_open)",
-	/* 275 */	"#275 (unimplemented mq_unlink)",
-	/* 276 */	"#276 (unimplemented mq_timedsend)",
-	/* 277 */	"#277 (unimplemented mq_timedreceive)",
-	/* 278 */	"#278 (unimplemented mq_notify)",
-	/* 279 */	"#279 (unimplemented mq_getsetattr)",
+	/* 274 */	"mq_open",
+	/* 275 */	"mq_unlink",
+	/* 276 */	"mq_timedsend",
+	/* 277 */	"mq_timedreceive",
+	/* 278 */	"mq_notify",
+	/* 279 */	"mq_getsetattr",
 	/* 280 */	"waitid",
 	/* 281 */	"#281 (unimplemented socket)",
 	/* 282 */	"#282 (unimplemented bind)",
@@ -831,12 +832,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 271 */	NULL, /* unimplemented pciconfig_iobase */
 	/* 272 */	NULL, /* unimplemented pciconfig_read */
 	/* 273 */	NULL, /* unimplemented pciconfig_write */
-	/* 274 */	NULL, /* unimplemented mq_open */
-	/* 275 */	NULL, /* unimplemented mq_unlink */
-	/* 276 */	NULL, /* unimplemented mq_timedsend */
-	/* 277 */	NULL, /* unimplemented mq_timedreceive */
-	/* 278 */	NULL, /* unimplemented mq_notify */
-	/* 279 */	NULL, /* unimplemented mq_getsetattr */
+	/* 274 */	NULL, /* mq_open */
+	/* 275 */	NULL, /* mq_unlink */
+	/* 276 */	NULL, /* mq_timedsend */
+	/* 277 */	NULL, /* mq_timedreceive */
+	/* 278 */	NULL, /* mq_notify */
+	/* 279 */	NULL, /* mq_getsetattr */
 	/* 280 */	NULL, /* waitid */
 	/* 281 */	NULL, /* unimplemented socket */
 	/* 282 */	NULL, /* unimplemented bind */

--- a/sys/compat/linux/arch/arm/linux_sysent.c
+++ b/sys/compat/linux/arch/arm/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.92 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.92 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/poll.h>
@@ -23,6 +23,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.92 2023/08/19 17:50:24 christos E
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 
 #define	s(type)	sizeof(type)
@@ -1199,23 +1200,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 273 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 274 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 274 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 275 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 275 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 276 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 276 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 277 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 277 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 278 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 278 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 279 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 279 = mq_getsetattr */
 	{
 		ns(struct linux_sys_waitid_args),
 		.sy_flags = SYCALL_ARG_PTR,

--- a/sys/compat/linux/arch/arm/linux_systrace_args.c
+++ b/sys/compat/linux/arch/arm/linux_systrace_args.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_systrace_args.c,v 1.25 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument to DTrace register array conversion.
@@ -1751,6 +1751,62 @@ systrace_args(register_t sysnum, const void *params, uintptr_t *uarg, size_t *n_
 		iarg[2] = SCARG(p, len); /* off_t */
 		iarg[3] = SCARG(p, advice); /* int */
 		*n_args = 4;
+		break;
+	}
+	/* linux_sys_mq_open */
+	case 274: {
+		const struct linux_sys_mq_open_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		iarg[1] = SCARG(p, oflag); /* int */
+		iarg[2] = SCARG(p, mode); /* linux_umode_t */
+		uarg[3] = (intptr_t) SCARG(p, attr); /* struct linux_mq_attr * */
+		*n_args = 4;
+		break;
+	}
+	/* linux_sys_mq_unlink */
+	case 275: {
+		const struct linux_sys_mq_unlink_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		*n_args = 1;
+		break;
+	}
+	/* linux_sys_mq_timedsend */
+	case 276: {
+		const struct linux_sys_mq_timedsend_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* const char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = SCARG(p, msg_prio); /* unsigned int */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_timedreceive */
+	case 277: {
+		const struct linux_sys_mq_timedreceive_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = (intptr_t) SCARG(p, msg_prio); /* unsigned int * */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_notify */
+	case 278: {
+		const struct linux_sys_mq_notify_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, sevp); /* const struct linux_sigevent * */
+		*n_args = 2;
+		break;
+	}
+	/* linux_sys_mq_getsetattr */
+	case 279: {
+		const struct linux_sys_mq_getsetattr_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, newattr); /* const struct linux_mq_attr * */
+		uarg[2] = (intptr_t) SCARG(p, oldattr); /* struct linux_mq_attr * */
+		*n_args = 3;
 		break;
 	}
 	/* linux_sys_waitid */
@@ -4977,6 +5033,108 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
+	/* linux_sys_mq_open */
+	case 274:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		case 1:
+			p = "int";
+			break;
+		case 2:
+			p = "linux_umode_t";
+			break;
+		case 3:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_unlink */
+	case 275:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedsend */
+	case 276:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 277:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int *";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_notify */
+	case 278:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_sigevent *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 279:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_mq_attr *";
+			break;
+		case 2:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
 	/* linux_sys_waitid */
 	case 280:
 		switch(ndx) {
@@ -6746,6 +6904,36 @@ systrace_return_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 		break;
 	/* linux_sys_fadvise64_64 */
 	case 270:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_open */
+	case 274:
+		if (ndx == 0 || ndx == 1)
+			p = "linux_mqd_t";
+		break;
+	/* linux_sys_mq_unlink */
+	case 275:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedsend */
+	case 276:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 277:
+		if (ndx == 0 || ndx == 1)
+			p = "ssize_t";
+		break;
+	/* linux_sys_mq_notify */
+	case 278:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 279:
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;

--- a/sys/compat/linux/arch/arm/syscalls.master
+++ b/sys/compat/linux/arch/arm/syscalls.master
@@ -48,6 +48,7 @@
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
+#include <compat/linux/common/linux_mqueue.h>
 
 #include <compat/linux/linux_syscallargs.h>
 
@@ -465,12 +466,23 @@
 271	UNIMPL		pciconfig_iobase
 272	UNIMPL		pciconfig_read
 273	UNIMPL		pciconfig_write
-274	UNIMPL		mq_open
-275	UNIMPL		mq_unlink
-276	UNIMPL		mq_timedsend
-277	UNIMPL		mq_timedreceive
-278	UNIMPL		mq_notify
-279	UNIMPL		mq_getsetattr
+274	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+275	STD		{ int|linux_sys||mq_unlink(const char *name); }
+276	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+277	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+278	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+279	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 280	STD		{ int|linux_sys||waitid(int idtype, id_t id, \
 			    linux_siginfo_t *infop, int options, \
 			    struct rusage50 *rusage); }

--- a/sys/compat/linux/arch/i386/linux_syscall.h
+++ b/sys/compat/linux/arch/i386/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.126 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -700,6 +700,24 @@
 
 /* syscall: "fadvise64_64" ret: "int" args: "int" "off_t" "off_t" "int" */
 #define	LINUX_SYS_fadvise64_64	272
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	277
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	278
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	279
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	280
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	281
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	282
 
 /* syscall: "waitid" ret: "int" args: "int" "id_t" "linux_siginfo_t *" "int" "struct rusage50 *" */
 #define	LINUX_SYS_waitid	284

--- a/sys/compat/linux/arch/i386/linux_syscallargs.h
+++ b/sys/compat/linux/arch/i386/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.126 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -1071,6 +1071,50 @@ struct linux_sys_fadvise64_64_args {
 };
 check_syscall_args(linux_sys_fadvise64_64)
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_waitid_args {
 	syscallarg(int) idtype;
 	syscallarg(id_t) id;
@@ -1765,6 +1809,18 @@ int	linux_sys_tgkill(struct lwp *, const struct linux_sys_tgkill_args *, registe
 int	compat_50_sys_utimes(struct lwp *, const struct compat_50_sys_utimes_args *, register_t *);
 
 int	linux_sys_fadvise64_64(struct lwp *, const struct linux_sys_fadvise64_64_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_waitid(struct lwp *, const struct linux_sys_waitid_args *, register_t *);
 

--- a/sys/compat/linux/arch/i386/linux_syscalls.c
+++ b/sys/compat/linux/arch/i386/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.127 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.127 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include <sys/param.h>
@@ -23,6 +23,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.127 2023/08/19 17:50:24 christo
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #else /* _KERNEL_OPT */
 #include <sys/null.h>
@@ -311,12 +312,12 @@ const char *const linux_syscallnames[] = {
 	/* 274 */	"#274 (unimplemented mbind)",
 	/* 275 */	"#275 (unimplemented get_mempolicy)",
 	/* 276 */	"#276 (unimplemented set_mempolicy)",
-	/* 277 */	"#277 (unimplemented mq_open)",
-	/* 278 */	"#278 (unimplemented mq_unlink)",
-	/* 279 */	"#279 (unimplemented mq_timedsend)",
-	/* 280 */	"#280 (unimplemented mq_timedreceive)",
-	/* 281 */	"#281 (unimplemented mq_notify)",
-	/* 282 */	"#282 (unimplemented mq_getsetattr)",
+	/* 277 */	"mq_open",
+	/* 278 */	"mq_unlink",
+	/* 279 */	"mq_timedsend",
+	/* 280 */	"mq_timedreceive",
+	/* 281 */	"mq_notify",
+	/* 282 */	"mq_getsetattr",
 	/* 283 */	"#283 (unimplemented sys_kexec_load)",
 	/* 284 */	"waitid",
 	/* 285 */	"#285 (unimplemented / * unused * /)",
@@ -833,12 +834,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 274 */	NULL, /* unimplemented mbind */
 	/* 275 */	NULL, /* unimplemented get_mempolicy */
 	/* 276 */	NULL, /* unimplemented set_mempolicy */
-	/* 277 */	NULL, /* unimplemented mq_open */
-	/* 278 */	NULL, /* unimplemented mq_unlink */
-	/* 279 */	NULL, /* unimplemented mq_timedsend */
-	/* 280 */	NULL, /* unimplemented mq_timedreceive */
-	/* 281 */	NULL, /* unimplemented mq_notify */
-	/* 282 */	NULL, /* unimplemented mq_getsetattr */
+	/* 277 */	NULL, /* mq_open */
+	/* 278 */	NULL, /* mq_unlink */
+	/* 279 */	NULL, /* mq_timedsend */
+	/* 280 */	NULL, /* mq_timedreceive */
+	/* 281 */	NULL, /* mq_notify */
+	/* 282 */	NULL, /* mq_getsetattr */
 	/* 283 */	NULL, /* unimplemented sys_kexec_load */
 	/* 284 */	NULL, /* waitid */
 	/* 285 */	NULL, /* unimplemented / * unused * / */

--- a/sys/compat/linux/arch/i386/linux_sysent.c
+++ b/sys/compat/linux/arch/i386/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.126 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.126 2023/08/19 17:50:24 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/poll.h>
@@ -22,6 +22,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.126 2023/08/19 17:50:24 christos 
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 
 #define	s(type)	sizeof(type)
@@ -1221,23 +1222,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 276 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 277 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 277 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 278 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 278 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 279 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 279 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 280 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 280 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 281 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 281 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 282 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 282 = mq_getsetattr */
 	{
 		.sy_call = linux_sys_nosys,
 	},		/* 283 = filler */

--- a/sys/compat/linux/arch/i386/linux_systrace_args.c
+++ b/sys/compat/linux/arch/i386/linux_systrace_args.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_systrace_args.c,v 1.21 2023/08/19 17:50:24 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument to DTrace register array conversion.
@@ -1814,6 +1814,62 @@ systrace_args(register_t sysnum, const void *params, uintptr_t *uarg, size_t *n_
 		iarg[2] = SCARG(p, len); /* off_t */
 		iarg[3] = SCARG(p, advice); /* int */
 		*n_args = 4;
+		break;
+	}
+	/* linux_sys_mq_open */
+	case 277: {
+		const struct linux_sys_mq_open_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		iarg[1] = SCARG(p, oflag); /* int */
+		iarg[2] = SCARG(p, mode); /* linux_umode_t */
+		uarg[3] = (intptr_t) SCARG(p, attr); /* struct linux_mq_attr * */
+		*n_args = 4;
+		break;
+	}
+	/* linux_sys_mq_unlink */
+	case 278: {
+		const struct linux_sys_mq_unlink_args *p = params;
+		uarg[0] = (intptr_t) SCARG(p, name); /* const char * */
+		*n_args = 1;
+		break;
+	}
+	/* linux_sys_mq_timedsend */
+	case 279: {
+		const struct linux_sys_mq_timedsend_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* const char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = SCARG(p, msg_prio); /* unsigned int */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_timedreceive */
+	case 280: {
+		const struct linux_sys_mq_timedreceive_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, msg_ptr); /* char * */
+		uarg[2] = SCARG(p, msg_len); /* size_t */
+		uarg[3] = (intptr_t) SCARG(p, msg_prio); /* unsigned int * */
+		uarg[4] = (intptr_t) SCARG(p, abs_timeout); /* const struct linux_timespec * */
+		*n_args = 5;
+		break;
+	}
+	/* linux_sys_mq_notify */
+	case 281: {
+		const struct linux_sys_mq_notify_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, sevp); /* const struct linux_sigevent * */
+		*n_args = 2;
+		break;
+	}
+	/* linux_sys_mq_getsetattr */
+	case 282: {
+		const struct linux_sys_mq_getsetattr_args *p = params;
+		iarg[0] = SCARG(p, mqdes); /* linux_mqd_t */
+		uarg[1] = (intptr_t) SCARG(p, newattr); /* const struct linux_mq_attr * */
+		uarg[2] = (intptr_t) SCARG(p, oldattr); /* struct linux_mq_attr * */
+		*n_args = 3;
 		break;
 	}
 	/* linux_sys_waitid */
@@ -5106,6 +5162,108 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
+	/* linux_sys_mq_open */
+	case 277:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		case 1:
+			p = "int";
+			break;
+		case 2:
+			p = "linux_umode_t";
+			break;
+		case 3:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_unlink */
+	case 278:
+		switch(ndx) {
+		case 0:
+			p = "const char *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedsend */
+	case 279:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 280:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "char *";
+			break;
+		case 2:
+			p = "size_t";
+			break;
+		case 3:
+			p = "unsigned int *";
+			break;
+		case 4:
+			p = "const struct linux_timespec *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_notify */
+	case 281:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_sigevent *";
+			break;
+		default:
+			break;
+		};
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 282:
+		switch(ndx) {
+		case 0:
+			p = "linux_mqd_t";
+			break;
+		case 1:
+			p = "const struct linux_mq_attr *";
+			break;
+		case 2:
+			p = "struct linux_mq_attr *";
+			break;
+		default:
+			break;
+		};
+		break;
 	/* linux_sys_waitid */
 	case 284:
 		switch(ndx) {
@@ -6855,6 +7013,36 @@ systrace_return_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 		break;
 	/* linux_sys_fadvise64_64 */
 	case 272:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_open */
+	case 277:
+		if (ndx == 0 || ndx == 1)
+			p = "linux_mqd_t";
+		break;
+	/* linux_sys_mq_unlink */
+	case 278:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedsend */
+	case 279:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_timedreceive */
+	case 280:
+		if (ndx == 0 || ndx == 1)
+			p = "ssize_t";
+		break;
+	/* linux_sys_mq_notify */
+	case 281:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* linux_sys_mq_getsetattr */
+	case 282:
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;

--- a/sys/compat/linux/arch/i386/syscalls.master
+++ b/sys/compat/linux/arch/i386/syscalls.master
@@ -47,6 +47,7 @@
 #include <compat/linux/common/linux_signal.h>
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
+#include <compat/linux/common/linux_mqueue.h>
 
 #include <compat/linux/linux_syscallargs.h>
 
@@ -468,12 +469,23 @@
 274	UNIMPL		mbind
 275	UNIMPL		get_mempolicy
 276	UNIMPL		set_mempolicy
-277	UNIMPL		mq_open
-278	UNIMPL		mq_unlink
-279	UNIMPL		mq_timedsend
-280	UNIMPL		mq_timedreceive
-281	UNIMPL		mq_notify
-282	UNIMPL		mq_getsetattr
+277	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+278	STD		{ int|linux_sys||mq_unlink(const char *name); }
+279	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+280	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+281	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+282	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 283	UNIMPL		sys_kexec_load
 284	STD		{ int|linux_sys||waitid(int idtype, id_t id, \
 			    linux_siginfo_t *infop, int options, \

--- a/sys/compat/linux/arch/m68k/linux_syscall.h
+++ b/sys/compat/linux/arch/m68k/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.117 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -683,6 +683,24 @@
 
 /* syscall: "fadvise64_64" ret: "int" args: "int" "off_t" "off_t" "int" */
 #define	LINUX_SYS_fadvise64_64	267
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	271
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	272
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	273
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	274
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	275
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	276
 
 /* syscall: "inotify_init" ret: "int" args: */
 #define	LINUX_SYS_inotify_init	284

--- a/sys/compat/linux/arch/m68k/linux_syscallargs.h
+++ b/sys/compat/linux/arch/m68k/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.116 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -1018,6 +1018,50 @@ struct linux_sys_fadvise64_64_args {
 };
 check_syscall_args(linux_sys_fadvise64_64)
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_inotify_add_watch_args {
 	syscallarg(int) fd;
 	syscallarg(const char *) pathname;
@@ -1728,6 +1772,18 @@ int	linux_sys_tgkill(struct lwp *, const struct linux_sys_tgkill_args *, registe
 int	compat_50_sys_utimes(struct lwp *, const struct compat_50_sys_utimes_args *, register_t *);
 
 int	linux_sys_fadvise64_64(struct lwp *, const struct linux_sys_fadvise64_64_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_inotify_init(struct lwp *, const void *, register_t *);
 

--- a/sys/compat/linux/arch/m68k/linux_syscalls.c
+++ b/sys/compat/linux/arch/m68k/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.117 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.117 2023/08/19 17:50:25 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #if defined(_KERNEL_OPT)
@@ -27,6 +27,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.117 2023/08/19 17:50:25 christo
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #else /* _KERNEL_OPT */
 #include <sys/null.h>
@@ -325,12 +326,12 @@ const char *const linux_syscallnames[] = {
 	/* 268 */	"#268 (unimplemented mbind)",
 	/* 269 */	"#269 (unimplemented get_mempolicy)",
 	/* 270 */	"#270 (unimplemented set_mempolicy)",
-	/* 271 */	"#271 (unimplemented mq_open)",
-	/* 272 */	"#272 (unimplemented mq_unlink)",
-	/* 273 */	"#273 (unimplemented mq_timedsend)",
-	/* 274 */	"#274 (unimplemented mq_timedreceive)",
-	/* 275 */	"#275 (unimplemented mq_notify)",
-	/* 276 */	"#276 (unimplemented mq_getsetattr)",
+	/* 271 */	"mq_open",
+	/* 272 */	"mq_unlink",
+	/* 273 */	"mq_timedsend",
+	/* 274 */	"mq_timedreceive",
+	/* 275 */	"mq_notify",
+	/* 276 */	"mq_getsetattr",
 	/* 277 */	"#277 (unimplemented waitid)",
 	/* 278 */	"#278 (unimplemented vserver)",
 	/* 279 */	"#279 (unimplemented add_key)",
@@ -863,12 +864,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 268 */	NULL, /* unimplemented mbind */
 	/* 269 */	NULL, /* unimplemented get_mempolicy */
 	/* 270 */	NULL, /* unimplemented set_mempolicy */
-	/* 271 */	NULL, /* unimplemented mq_open */
-	/* 272 */	NULL, /* unimplemented mq_unlink */
-	/* 273 */	NULL, /* unimplemented mq_timedsend */
-	/* 274 */	NULL, /* unimplemented mq_timedreceive */
-	/* 275 */	NULL, /* unimplemented mq_notify */
-	/* 276 */	NULL, /* unimplemented mq_getsetattr */
+	/* 271 */	NULL, /* mq_open */
+	/* 272 */	NULL, /* mq_unlink */
+	/* 273 */	NULL, /* mq_timedsend */
+	/* 274 */	NULL, /* mq_timedreceive */
+	/* 275 */	NULL, /* mq_notify */
+	/* 276 */	NULL, /* mq_getsetattr */
 	/* 277 */	NULL, /* unimplemented waitid */
 	/* 278 */	NULL, /* unimplemented vserver */
 	/* 279 */	NULL, /* unimplemented add_key */

--- a/sys/compat/linux/arch/m68k/linux_sysent.c
+++ b/sys/compat/linux/arch/m68k/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.117 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.117 2023/08/19 17:50:25 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include "opt_compat_netbsd.h"
@@ -26,6 +26,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.117 2023/08/19 17:50:25 christos 
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 
 #define	s(type)	sizeof(type)
@@ -1209,23 +1210,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 270 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 271 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 271 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 272 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 272 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 273 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 273 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 274 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 274 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 275 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 275 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 276 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 276 = mq_getsetattr */
 	{
 		.sy_call = linux_sys_nosys,
 	},		/* 277 = filler */

--- a/sys/compat/linux/arch/m68k/syscalls.master
+++ b/sys/compat/linux/arch/m68k/syscalls.master
@@ -51,6 +51,7 @@
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 
 #include <compat/linux/linux_syscallargs.h>
 
@@ -477,12 +478,23 @@
 268	UNIMPL		mbind
 269	UNIMPL		get_mempolicy
 270	UNIMPL		set_mempolicy
-271	UNIMPL		mq_open
-272	UNIMPL		mq_unlink
-273	UNIMPL		mq_timedsend
-274	UNIMPL		mq_timedreceive
-275	UNIMPL		mq_notify
-276	UNIMPL		mq_getsetattr
+271	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+272	STD		{ int|linux_sys||mq_unlink(const char *name); }
+273	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+274	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+275	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+276	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 277	UNIMPL		waitid
 278	UNIMPL		vserver
 279	UNIMPL		add_key

--- a/sys/compat/linux/arch/mips/linux_syscall.h
+++ b/sys/compat/linux/arch/mips/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.90 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -654,6 +654,24 @@
 
 /* syscall: "utimes" ret: "int" args: "const char *" "const struct timeval50 *" */
 #define	LINUX_SYS_utimes	267
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	271
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	272
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	273
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	274
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	275
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	276
 
 /* syscall: "waitid" ret: "int" args: "int" "id_t" "linux_siginfo_t *" "int" "struct rusage50 *" */
 #define	LINUX_SYS_waitid	278

--- a/sys/compat/linux/arch/mips/linux_syscallargs.h
+++ b/sys/compat/linux/arch/mips/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.89 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -1065,6 +1065,50 @@ check_syscall_args(linux_sys_tgkill)
 
 struct compat_50_sys_utimes_args;
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_waitid_args {
 	syscallarg(int) idtype;
 	syscallarg(id_t) id;
@@ -1777,6 +1821,18 @@ int	linux_sys_clock_nanosleep(struct lwp *, const struct linux_sys_clock_nanosle
 int	linux_sys_tgkill(struct lwp *, const struct linux_sys_tgkill_args *, register_t *);
 
 int	compat_50_sys_utimes(struct lwp *, const struct compat_50_sys_utimes_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_waitid(struct lwp *, const struct linux_sys_waitid_args *, register_t *);
 

--- a/sys/compat/linux/arch/mips/linux_syscalls.c
+++ b/sys/compat/linux/arch/mips/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.89 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.89 2023/08/19 17:50:25 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include <sys/param.h>
@@ -23,6 +23,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.89 2023/08/19 17:50:25 christos
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
 #include <compat/linux/common/linux_socketcall.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #define linux_sys_mmap2_args linux_sys_mmap_args
 #else /* _KERNEL_OPT */
@@ -301,12 +302,12 @@ const char *const linux_syscallnames[] = {
 	/* 268 */	"#268 (unimplemented mbind)",
 	/* 269 */	"#269 (unimplemented get_mempolicy)",
 	/* 270 */	"#270 (unimplemented set_mempolicy)",
-	/* 271 */	"#271 (unimplemented mq_open)",
-	/* 272 */	"#272 (unimplemented mq_unlink)",
-	/* 273 */	"#273 (unimplemented mq_timedsend)",
-	/* 274 */	"#274 (unimplemented mq_timedreceive)",
-	/* 275 */	"#275 (unimplemented mq_notify)",
-	/* 276 */	"#276 (unimplemented mq_getsetattr)",
+	/* 271 */	"mq_open",
+	/* 272 */	"mq_unlink",
+	/* 273 */	"mq_timedsend",
+	/* 274 */	"mq_timedreceive",
+	/* 275 */	"mq_notify",
+	/* 276 */	"mq_getsetattr",
 	/* 277 */	"#277 (unimplemented vserve)",
 	/* 278 */	"waitid",
 	/* 279 */	"#279 (unimplemented setaltroot)",
@@ -818,12 +819,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 268 */	NULL, /* unimplemented mbind */
 	/* 269 */	NULL, /* unimplemented get_mempolicy */
 	/* 270 */	NULL, /* unimplemented set_mempolicy */
-	/* 271 */	NULL, /* unimplemented mq_open */
-	/* 272 */	NULL, /* unimplemented mq_unlink */
-	/* 273 */	NULL, /* unimplemented mq_timedsend */
-	/* 274 */	NULL, /* unimplemented mq_timedreceive */
-	/* 275 */	NULL, /* unimplemented mq_notify */
-	/* 276 */	NULL, /* unimplemented mq_getsetattr */
+	/* 271 */	NULL, /* mq_open */
+	/* 272 */	NULL, /* mq_unlink */
+	/* 273 */	NULL, /* mq_timedsend */
+	/* 274 */	NULL, /* mq_timedreceive */
+	/* 275 */	NULL, /* mq_notify */
+	/* 276 */	NULL, /* mq_getsetattr */
 	/* 277 */	NULL, /* unimplemented vserve */
 	/* 278 */	NULL, /* waitid */
 	/* 279 */	NULL, /* unimplemented setaltroot */

--- a/sys/compat/linux/arch/mips/linux_sysent.c
+++ b/sys/compat/linux/arch/mips/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.89 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.89 2023/08/19 17:50:25 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/poll.h>
@@ -22,6 +22,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.89 2023/08/19 17:50:25 christos E
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
 #include <compat/linux/common/linux_socketcall.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #define linux_sys_mmap2_args linux_sys_mmap_args
 
@@ -1189,23 +1190,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 270 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 271 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 271 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 272 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 272 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 273 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 273 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 274 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 274 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 275 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 275 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 276 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 276 = mq_getsetattr */
 	{
 		.sy_call = linux_sys_nosys,
 	},		/* 277 = filler */

--- a/sys/compat/linux/arch/mips/syscalls.master
+++ b/sys/compat/linux/arch/mips/syscalls.master
@@ -53,6 +53,7 @@
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
 #include <compat/linux/common/linux_socketcall.h>
+#include <compat/linux/common/linux_mqueue.h>
 
 #include <compat/linux/linux_syscallargs.h>
 
@@ -467,12 +468,23 @@
 268	UNIMPL		mbind
 269	UNIMPL		get_mempolicy
 270	UNIMPL		set_mempolicy
-271	UNIMPL		mq_open
-272	UNIMPL		mq_unlink
-273	UNIMPL		mq_timedsend
-274	UNIMPL		mq_timedreceive
-275	UNIMPL		mq_notify
-276	UNIMPL		mq_getsetattr
+271	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+272	STD		{ int|linux_sys||mq_unlink(const char *name); }
+273	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+274	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+275	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+276	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 277	UNIMPL		vserve
 278	STD		{ int|linux_sys||waitid(int idtype, id_t id, \
 			    linux_siginfo_t *infop, int options, \

--- a/sys/compat/linux/arch/powerpc/linux_syscall.h
+++ b/sys/compat/linux/arch/powerpc/linux_syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscall.h,v 1.96 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -626,6 +626,24 @@
 
 /* syscall: "fadvise64_64" ret: "int" args: "int" "off_t" "off_t" "int" */
 #define	LINUX_SYS_fadvise64_64	254
+
+/* syscall: "mq_open" ret: "linux_mqd_t" args: "const char *" "int" "linux_umode_t" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_open	262
+
+/* syscall: "mq_unlink" ret: "int" args: "const char *" */
+#define	LINUX_SYS_mq_unlink	263
+
+/* syscall: "mq_timedsend" ret: "int" args: "linux_mqd_t" "const char *" "size_t" "unsigned int" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedsend	264
+
+/* syscall: "mq_timedreceive" ret: "ssize_t" args: "linux_mqd_t" "char *" "size_t" "unsigned int *" "const struct linux_timespec *" */
+#define	LINUX_SYS_mq_timedreceive	265
+
+/* syscall: "mq_notify" ret: "int" args: "linux_mqd_t" "const struct linux_sigevent *" */
+#define	LINUX_SYS_mq_notify	266
+
+/* syscall: "mq_getsetattr" ret: "int" args: "linux_mqd_t" "const struct linux_mq_attr *" "struct linux_mq_attr *" */
+#define	LINUX_SYS_mq_getsetattr	267
 
 /* syscall: "waitid" ret: "int" args: "int" "id_t" "linux_siginfo_t *" "int" "struct rusage50 *" */
 #define	LINUX_SYS_waitid	272

--- a/sys/compat/linux/arch/powerpc/linux_syscallargs.h
+++ b/sys/compat/linux/arch/powerpc/linux_syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscallargs.h,v 1.95 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -957,6 +957,50 @@ struct linux_sys_fadvise64_64_args {
 };
 check_syscall_args(linux_sys_fadvise64_64)
 
+struct linux_sys_mq_open_args {
+	syscallarg(const char *) name;
+	syscallarg(int) oflag;
+	syscallarg(linux_umode_t) mode;
+	syscallarg(struct linux_mq_attr *) attr;
+};
+check_syscall_args(linux_sys_mq_open)
+
+struct linux_sys_mq_unlink_args {
+	syscallarg(const char *) name;
+};
+check_syscall_args(linux_sys_mq_unlink)
+
+struct linux_sys_mq_timedsend_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedsend)
+
+struct linux_sys_mq_timedreceive_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(char *) msg_ptr;
+	syscallarg(size_t) msg_len;
+	syscallarg(unsigned int *) msg_prio;
+	syscallarg(const struct linux_timespec *) abs_timeout;
+};
+check_syscall_args(linux_sys_mq_timedreceive)
+
+struct linux_sys_mq_notify_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_sigevent *) sevp;
+};
+check_syscall_args(linux_sys_mq_notify)
+
+struct linux_sys_mq_getsetattr_args {
+	syscallarg(linux_mqd_t) mqdes;
+	syscallarg(const struct linux_mq_attr *) newattr;
+	syscallarg(struct linux_mq_attr *) oldattr;
+};
+check_syscall_args(linux_sys_mq_getsetattr)
+
 struct linux_sys_waitid_args {
 	syscallarg(int) idtype;
 	syscallarg(id_t) id;
@@ -1636,6 +1680,18 @@ int	linux_sys_statfs64(struct lwp *, const struct linux_sys_statfs64_args *, reg
 int	linux_sys_fstatfs64(struct lwp *, const struct linux_sys_fstatfs64_args *, register_t *);
 
 int	linux_sys_fadvise64_64(struct lwp *, const struct linux_sys_fadvise64_64_args *, register_t *);
+
+int	linux_sys_mq_open(struct lwp *, const struct linux_sys_mq_open_args *, register_t *);
+
+int	linux_sys_mq_unlink(struct lwp *, const struct linux_sys_mq_unlink_args *, register_t *);
+
+int	linux_sys_mq_timedsend(struct lwp *, const struct linux_sys_mq_timedsend_args *, register_t *);
+
+int	linux_sys_mq_timedreceive(struct lwp *, const struct linux_sys_mq_timedreceive_args *, register_t *);
+
+int	linux_sys_mq_notify(struct lwp *, const struct linux_sys_mq_notify_args *, register_t *);
+
+int	linux_sys_mq_getsetattr(struct lwp *, const struct linux_sys_mq_getsetattr_args *, register_t *);
 
 int	linux_sys_waitid(struct lwp *, const struct linux_sys_waitid_args *, register_t *);
 

--- a/sys/compat/linux/arch/powerpc/linux_syscalls.c
+++ b/sys/compat/linux/arch/powerpc/linux_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_syscalls.c,v 1.95 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.95 2023/08/19 17:50:25 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #include <sys/param.h>
@@ -22,6 +22,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_syscalls.c,v 1.95 2023/08/19 17:50:25 christos
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 #else /* _KERNEL_OPT */
 #include <sys/null.h>
@@ -295,12 +296,12 @@ const char *const linux_syscallnames[] = {
 	/* 259 */	"#259 (unimplemented / * reserved for new sys_mbind * /)",
 	/* 260 */	"#260 (unimplemented / * reserved for new sys_get_mempolicy * /)",
 	/* 261 */	"#261 (unimplemented / * reserved for new sys_set_mempolicy * /)",
-	/* 262 */	"#262 (unimplemented mq_open)",
-	/* 263 */	"#263 (unimplemented mq_unlink)",
-	/* 264 */	"#264 (unimplemented mq_timedsend)",
-	/* 265 */	"#265 (unimplemented mq_timedreceive)",
-	/* 266 */	"#266 (unimplemented mq_notify)",
-	/* 267 */	"#267 (unimplemented mq_getsetattr)",
+	/* 262 */	"mq_open",
+	/* 263 */	"mq_unlink",
+	/* 264 */	"mq_timedsend",
+	/* 265 */	"mq_timedreceive",
+	/* 266 */	"mq_notify",
+	/* 267 */	"mq_getsetattr",
 	/* 268 */	"#268 (unimplemented kexec_load)",
 	/* 269 */	"#269 (unimplemented add_key)",
 	/* 270 */	"#270 (unimplemented request_key)",
@@ -817,12 +818,12 @@ const char *const altlinux_syscallnames[] = {
 	/* 259 */	NULL, /* unimplemented / * reserved for new sys_mbind * / */
 	/* 260 */	NULL, /* unimplemented / * reserved for new sys_get_mempolicy * / */
 	/* 261 */	NULL, /* unimplemented / * reserved for new sys_set_mempolicy * / */
-	/* 262 */	NULL, /* unimplemented mq_open */
-	/* 263 */	NULL, /* unimplemented mq_unlink */
-	/* 264 */	NULL, /* unimplemented mq_timedsend */
-	/* 265 */	NULL, /* unimplemented mq_timedreceive */
-	/* 266 */	NULL, /* unimplemented mq_notify */
-	/* 267 */	NULL, /* unimplemented mq_getsetattr */
+	/* 262 */	NULL, /* mq_open */
+	/* 263 */	NULL, /* mq_unlink */
+	/* 264 */	NULL, /* mq_timedsend */
+	/* 265 */	NULL, /* mq_timedreceive */
+	/* 266 */	NULL, /* mq_notify */
+	/* 267 */	NULL, /* mq_getsetattr */
 	/* 268 */	NULL, /* unimplemented kexec_load */
 	/* 269 */	NULL, /* unimplemented add_key */
 	/* 270 */	NULL, /* unimplemented request_key */

--- a/sys/compat/linux/arch/powerpc/linux_sysent.c
+++ b/sys/compat/linux/arch/powerpc/linux_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: linux_sysent.c,v 1.96 2023/08/19 17:50:25 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.96 2023/08/19 17:50:25 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/poll.h>
@@ -21,6 +21,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_sysent.c,v 1.96 2023/08/19 17:50:25 christos E
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 #include <compat/linux/linux_syscallargs.h>
 
 #define	s(type)	sizeof(type)
@@ -1143,23 +1144,35 @@ struct sysent linux_sysent[] = {
 		.sy_call = linux_sys_nosys,
 	},		/* 261 = filler */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 262 = filler */
+		ns(struct linux_sys_mq_open_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_open
+	},		/* 262 = mq_open */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 263 = filler */
+		ns(struct linux_sys_mq_unlink_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_unlink
+	},		/* 263 = mq_unlink */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 264 = filler */
+		ns(struct linux_sys_mq_timedsend_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedsend
+	},		/* 264 = mq_timedsend */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 265 = filler */
+		ns(struct linux_sys_mq_timedreceive_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_timedreceive
+	},		/* 265 = mq_timedreceive */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 266 = filler */
+		ns(struct linux_sys_mq_notify_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_notify
+	},		/* 266 = mq_notify */
 	{
-		.sy_call = linux_sys_nosys,
-	},		/* 267 = filler */
+		ns(struct linux_sys_mq_getsetattr_args),
+		.sy_flags = SYCALL_ARG_PTR,
+		.sy_call = (sy_call_t *)linux_sys_mq_getsetattr
+	},		/* 267 = mq_getsetattr */
 	{
 		.sy_call = linux_sys_nosys,
 	},		/* 268 = filler */

--- a/sys/compat/linux/arch/powerpc/syscalls.master
+++ b/sys/compat/linux/arch/powerpc/syscalls.master
@@ -74,6 +74,7 @@
 #include <compat/linux/common/linux_siginfo.h>
 #include <compat/linux/common/linux_machdep.h>
 #include <compat/linux/common/linux_mmap.h>
+#include <compat/linux/common/linux_mqueue.h>
 
 #include <compat/linux/linux_syscallargs.h>
 
@@ -468,12 +469,23 @@
 259	UNIMPL		/* reserved for new sys_mbind */
 260	UNIMPL		/* reserved for new sys_get_mempolicy */
 261	UNIMPL		/* reserved for new sys_set_mempolicy */
-262	UNIMPL		mq_open
-263	UNIMPL		mq_unlink
-264	UNIMPL		mq_timedsend
-265	UNIMPL		mq_timedreceive
-266	UNIMPL		mq_notify
-267	UNIMPL		mq_getsetattr
+262	STD		{ linux_mqd_t|linux_sys||mq_open(const char *name, \
+			    int oflag, linux_umode_t mode, \
+			    struct linux_mq_attr *attr); }
+263	STD		{ int|linux_sys||mq_unlink(const char *name); }
+264	STD		{ int|linux_sys||mq_timedsend(linux_mqd_t mqdes, \
+			    const char *msg_ptr, size_t msg_len, \
+			    unsigned int msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+265	STD		{ ssize_t|linux_sys||mq_timedreceive(linux_mqd_t mqdes, \
+			    char *msg_ptr, size_t msg_len, \
+			    unsigned int *msg_prio, \
+			    const struct linux_timespec *abs_timeout); }
+266	STD		{ int|linux_sys||mq_notify(linux_mqd_t mqdes, \
+			    const struct linux_sigevent *sevp); }
+267	STD		{ int|linux_sys||mq_getsetattr(linux_mqd_t mqdes, \
+			    const struct linux_mq_attr *newattr, \
+			    struct linux_mq_attr *oldattr); }
 268	UNIMPL		kexec_load
 269	UNIMPL		add_key
 270	UNIMPL		request_key

--- a/sys/compat/linux/common/linux_mod.c
+++ b/sys/compat/linux/common/linux_mod.c
@@ -66,7 +66,7 @@ __KERNEL_RCSID(0, "$NetBSD: linux_mod.c,v 1.15 2023/08/19 17:57:54 christos Exp 
 # define	MD3	""
 #endif
 
-#define REQ1    "compat_ossaudio,sysv_ipc,compat_util"
+#define REQ1    "compat_ossaudio,sysv_ipc,mqueue,compat_util"
 #define REQ2    ",compat_50,compat_43"
 
 MODULE(MODULE_CLASS_EXEC, compat_linux, REQ1 REQ2 MD1 MD2 MD3);

--- a/sys/compat/linux/common/linux_mqueue.c
+++ b/sys/compat/linux/common/linux_mqueue.c
@@ -1,0 +1,313 @@
+/*	$NetBSD	*/
+
+/*-
+ * Copyright (c) 2024 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__KERNEL_RCSID(0, "$NetBSD$");
+
+#include <sys/param.h>
+#include <sys/filedesc.h>
+#include <sys/fcntl.h>
+#include <sys/mqueue.h>
+#include <sys/syscallargs.h>
+
+#include <compat/linux/common/linux_types.h>
+#include <compat/linux/common/linux_sched.h>
+#include <compat/linux/common/linux_fcntl.h>
+#include <compat/linux/common/linux_ipc.h>
+#include <compat/linux/common/linux_sem.h>
+#include <compat/linux/common/linux_signal.h>
+#include <compat/linux/common/linux_sigevent.h>
+#include <compat/linux/common/linux_util.h>
+#include <compat/linux/common/linux_mqueue.h>
+
+#include <compat/linux/linux_syscallargs.h>
+#include <compat/linux/linux_syscall.h>
+
+static void
+linux_to_bsd_mq_attr(const struct linux_mq_attr *lmp, struct mq_attr *bmp)
+{
+	memset(bmp, 0, sizeof(*bmp));
+	bmp->mq_flags = cvtto_bsd_mask(lmp->mq_flags, LINUX_O_NONBLOCK, O_NONBLOCK);
+	bmp->mq_maxmsg = lmp->mq_maxmsg;
+	bmp->mq_msgsize = lmp->mq_msgsize;
+	bmp->mq_curmsgs = lmp->mq_curmsgs;
+}
+
+static void
+bsd_to_linux_mq_attr(const struct mq_attr *bmp, struct linux_mq_attr *lmp)
+{
+	memset(lmp, 0, sizeof(*lmp));
+	lmp->mq_flags = cvtto_linux_mask(bmp->mq_flags, O_NONBLOCK, LINUX_O_NONBLOCK);
+	lmp->mq_maxmsg = bmp->mq_maxmsg;
+	lmp->mq_msgsize = bmp->mq_msgsize;
+	lmp->mq_curmsgs = bmp->mq_curmsgs;
+}
+
+/* Adapted from sys_mq_open */
+int
+linux_sys_mq_open(struct lwp *l, const struct linux_sys_mq_open_args *uap,
+    register_t *retval)
+{
+	/* {
+		syscallarg(const char *) name;
+		syscallarg(int) oflag;
+		syscallarg(linux_umode_t) mode;
+		syscallarg(struct linux_mq_attr *) attr;
+	} */
+	struct linux_mq_attr lattr;
+	struct mq_attr *attr = NULL, a;
+	int error, oflag;
+
+	oflag = linux_to_bsd_ioflags(SCARG(uap, oflag));
+
+	if ((oflag & O_CREAT) != 0 && SCARG(uap, attr) != NULL) {
+		error = copyin(SCARG(uap, attr), &lattr, sizeof(lattr));
+		if (error)
+			return error;
+		linux_to_bsd_mq_attr(&lattr, &a);
+		attr = &a;
+	}
+
+	return mq_handle_open(l, SCARG(uap, name), oflag,
+	    (mode_t)SCARG(uap, mode), attr, retval);
+}
+
+int
+linux_sys_mq_unlink(struct lwp *l, const struct linux_sys_mq_unlink_args *uap,
+    register_t *retval)
+{
+	/* {
+		syscallarg(const char *) name;
+	} */
+	struct sys_mq_unlink_args args;
+
+	SCARG(&args, name) = SCARG(uap, name);
+
+	return sys_mq_unlink(l, &args, retval);
+}
+
+/* Adapted from sys___mq_timedsend50 */
+int
+linux_sys_mq_timedsend(struct lwp *l, const struct linux_sys_mq_timedsend_args *uap,
+    register_t *retval)
+{
+	/* {
+		syscallarg(linux_mqd_t) mqdes;
+		syscallarg(const char *) msg_ptr;
+		syscallarg(size_t) msg_len;
+		syscallarg(unsigned int) msg_prio;
+		syscallarg(const struct linux_timespec *) abs_timeout;
+	} */
+	struct linux_timespec lts;
+	struct timespec ts, *tsp;
+	int error;
+
+	/* Get and convert time value */
+	if (SCARG(uap, abs_timeout)) {
+		error = copyin(SCARG(uap, abs_timeout), &lts, sizeof(lts));
+		if (error)
+			return error;
+		linux_to_native_timespec(&ts, &lts);
+		tsp = &ts;
+	} else {
+		tsp = NULL;
+	}
+
+	return mq_send1((mqd_t)SCARG(uap, mqdes), SCARG(uap, msg_ptr),
+	    SCARG(uap, msg_len), SCARG(uap, msg_prio), tsp);
+}
+
+/* Adapted from sys___mq_timedreceive50 */
+int
+linux_sys_mq_timedreceive(struct lwp *l,
+    const struct linux_sys_mq_timedreceive_args *uap, register_t *retval)
+{
+	/* {
+		syscallarg(linux_mqd_t) mqdes;
+		syscallarg(char *) msg_ptr;
+		syscallarg(size_t) msg_len;
+		syscallarg(unsigned int *) msg_prio;
+		syscallarg(const struct linux_timespec *) abs_timeout;
+	}; */
+	struct linux_timespec lts;
+	struct timespec ts, *tsp;
+	ssize_t mlen;
+	int error;
+
+	/* Get and convert time value */
+	if (SCARG(uap, abs_timeout)) {
+		error = copyin(SCARG(uap, abs_timeout), &lts, sizeof(lts));
+		if (error)
+			return error;
+		linux_to_native_timespec(&ts, &lts);
+		tsp = &ts;
+	} else {
+		tsp = NULL;
+	}
+
+	error = mq_recv1((mqd_t)SCARG(uap, mqdes), SCARG(uap, msg_ptr),
+	    SCARG(uap, msg_len), SCARG(uap, msg_prio), tsp, &mlen);
+	if (error == 0)
+		*retval = mlen;
+
+	return error;
+}
+
+/* Adapted from sys_mq_notify */
+int
+linux_sys_mq_notify(struct lwp *l, const struct linux_sys_mq_notify_args *uap,
+    register_t *retval)
+{
+	/* {
+		syscallarg(linux_mqd_t) mqdes;
+		syscallarg(const struct linux_sigevent *) sevp;
+	} */
+	struct mqueue *mq;
+	struct sigevent sig;
+	int error;
+
+	if (SCARG(uap, sevp)) {
+		/* Get the signal from user-space */
+		error = linux_sigevent_copyin(SCARG(uap, sevp), &sig, sizeof(sig));
+		if (error)
+			return error;
+		if (sig.sigev_notify == SIGEV_SIGNAL &&
+		    (sig.sigev_signo <=0 || sig.sigev_signo >= NSIG))
+			return EINVAL;
+	}
+
+	error = mqueue_get((mqd_t)SCARG(uap, mqdes), 0, &mq);
+	if (error)
+		return error;
+	if (SCARG(uap, sevp)) {
+		/* Register notification: set the signal and target process */
+		if (mq->mq_notify_proc == NULL) {
+			memcpy(&mq->mq_sig_notify, &sig,
+			    sizeof(struct sigevent));
+			mq->mq_notify_proc = l->l_proc;
+		} else {
+			/* Fail if someone else already registered */
+			error = EBUSY;
+		}
+	} else {
+		/* Unregister the notification */
+		mq->mq_notify_proc = NULL;
+	}
+	mutex_exit(&mq->mq_mtx);
+	fd_putfile((int)SCARG(uap, mqdes));
+
+	return error;
+}
+
+/* Adapted from sys_mq_getattr */
+static int
+linux_sys_mq_getattr(struct lwp *l,
+    const struct linux_sys_mq_getsetattr_args *uap, register_t *retval)
+{
+	/* {
+		syscallarg(linux_mqd_t) mqdes;
+		syscallarg(const struct linux_mq_attr *) newattr;
+		syscallarg(struct linux_mq_attr *) oldattr;
+	} */
+	struct linux_mq_attr lattr;
+	struct mq_attr attr;
+	struct mqueue *mq;
+	int error;
+
+	error = mqueue_get((mqd_t)SCARG(uap, mqdes), 0, &mq);
+	if (error)
+		return error;
+	memcpy(&attr, &mq->mq_attrib, sizeof(struct mq_attr));
+	bsd_to_linux_mq_attr(&attr, &lattr);
+	mutex_exit(&mq->mq_mtx);
+	fd_putfile((int)SCARG(uap, mqdes));
+
+	return copyout(&lattr, SCARG(uap, oldattr), sizeof(lattr));
+}
+
+/* Adapted from sys_mq_setattr */
+static int
+linux_sys_mq_setattr(struct lwp *l,
+    const struct linux_sys_mq_getsetattr_args *uap, register_t *retval)
+{
+	/* {
+		syscallarg(linux_mqd_t) mqdes;
+		syscallarg(const struct linux_mq_attr *) newattr;
+		syscallarg(struct linux_mq_attr *) oldattr;
+	} */
+	struct linux_mq_attr lattr;
+	struct mq_attr attr;
+	struct mqueue *mq;
+	int error, nonblock;
+
+	error = copyin(SCARG(uap, newattr), &lattr, sizeof(lattr));
+	if (error)
+		return error;
+	linux_to_bsd_mq_attr(&lattr, &attr);
+	nonblock = (attr.mq_flags & O_NONBLOCK);
+
+	error = mqueue_get((mqd_t)SCARG(uap, mqdes), 0, &mq);
+	if (error)
+		return error;
+
+	/* Copy the old attributes, if needed */
+	if (SCARG(uap, oldattr)) {
+		memcpy(&attr, &mq->mq_attrib, sizeof(struct mq_attr));
+		bsd_to_linux_mq_attr(&attr, &lattr);
+	}
+
+	/* Ignore everything, except O_NONBLOCK */
+	if (nonblock)
+		mq->mq_attrib.mq_flags |= O_NONBLOCK;
+	else
+		mq->mq_attrib.mq_flags &= ~O_NONBLOCK;
+
+	mutex_exit(&mq->mq_mtx);
+	fd_putfile((int)SCARG(uap, mqdes));
+
+	/* Copy the data to the user-space. */
+	if (SCARG(uap, oldattr))
+		error = copyout(&lattr, SCARG(uap, oldattr), sizeof(lattr));
+
+	return error;
+}
+
+int
+linux_sys_mq_getsetattr(struct lwp *l,
+    const struct linux_sys_mq_getsetattr_args *uap, register_t *retval)
+{
+	/* {
+		syscallarg(linux_mqd_t) mqdes;
+		syscallarg(const struct linux_mq_attr *) newattr;
+		syscallarg(struct linux_mq_attr *) oldattr;
+	} */
+	if (SCARG(uap, newattr) != NULL)
+		return linux_sys_mq_setattr(l, uap, retval);
+	else
+		return linux_sys_mq_getattr(l, uap, retval);
+}

--- a/sys/compat/linux/common/linux_mqueue.h
+++ b/sys/compat/linux/common/linux_mqueue.h
@@ -1,0 +1,40 @@
+/*	$NetBSD	*/
+
+/*-
+ * Copyright (c) 2024 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _LINUX_MQUEUE_H
+#define _LINUX_MQUEUE_H
+
+struct linux_mq_attr {
+	long	mq_flags;	/* message queue flags			*/
+	long	mq_maxmsg;	/* maximum number of messages		*/
+	long	mq_msgsize;	/* maximum message size			*/
+	long	mq_curmsgs;	/* number of messages currently queued  */
+	long	__reserved[4];	/* ignored for input, zeroed for output */
+};
+
+#endif /* !_LINUX_MQUEUE_H */

--- a/sys/compat/linux/common/linux_types.h
+++ b/sys/compat/linux/common/linux_types.h
@@ -58,6 +58,8 @@ typedef unsigned short linux_gid16_t;
 typedef unsigned short linux_uid16_t;
 typedef unsigned short linux_umode_t;
 
+typedef long linux_mqd_t;
+
 /*
  * From Linux include/asm-.../posix_types.h
  */

--- a/sys/kern/sys_mqueue.c
+++ b/sys/kern/sys_mqueue.c
@@ -70,11 +70,11 @@ __KERNEL_RCSID(0, "$NetBSD: sys_mqueue.c,v 1.48 2020/05/23 23:42:43 ad Exp $");
 MODULE(MODULE_CLASS_MISC, mqueue, NULL);
 
 /* System-wide limits. */
-static u_int			mq_open_max = MQ_OPEN_MAX;
-static u_int			mq_prio_max = MQ_PRIO_MAX;
-static u_int			mq_max_msgsize = 16 * MQ_DEF_MSGSIZE;
-static u_int			mq_def_maxmsg = 32;
-static u_int			mq_max_maxmsg = 16 * 32;
+u_int			mq_open_max = MQ_OPEN_MAX;
+static u_int		mq_prio_max = MQ_PRIO_MAX;
+u_int			mq_max_msgsize = 16 * MQ_DEF_MSGSIZE;
+u_int			mq_def_maxmsg = 32;
+u_int			mq_max_maxmsg = 16 * 32;
 
 static pool_cache_t		mqmsg_cache	__read_mostly;
 static kmutex_t			mqlist_lock	__cacheline_aligned;

--- a/sys/miscfs/procfs/procfs.h
+++ b/sys/miscfs/procfs/procfs.h
@@ -103,6 +103,12 @@ typedef enum {
 	PFSmem,		/* the process's memory image */
 	PFSmeminfo,	/* system memory info (if -o linux) */
 	PFSmounts,	/* mounted filesystems (if -o linux) */
+	PFSmqueue,	/* sys/fs/mqueue subdirectory (if -o linux) */
+	PFSmq_msg_def,	/* sys/fs/mqueue/msg_default (if -o linux) */
+	PFSmq_msg_max,	/* sys/fs/mqueue/msg_max (if -o linux) */
+	PFSmq_siz_def,	/* sys/fs/mqueue/msgsize_default (if -o linux) */
+	PFSmq_siz_max,	/* sys/fs/mqueue/msgsize_max (if -o linux) */
+	PFSmq_qmax,	/* sys/fs/mqueue/queues_max (if -o linux) */
 	PFSnote,	/* process notifier */
 	PFSnotepg,	/* process group notifier */
 	PFSproc,	/* a process-specific sub-directory */
@@ -112,6 +118,8 @@ typedef enum {
 	PFSstat,	/* process status (if -o linux) */
 	PFSstatm,	/* process memory info (if -o linux) */
 	PFSstatus,	/* process status */
+	PFSsys,		/* sys subdirectory (if -o linux) */
+	PFSsysfs,	/* sys/fs subdirectory (if -o linux) */
 	PFSsysvipc,	/* sysvipc subdirectory (if -o linux) */
 	PFSsysvipc_msg,	/* sysvipc msg info (if -o linux) */
 	PFSsysvipc_sem,	/* sysvipc sem info (if -o linux) */
@@ -275,6 +283,16 @@ int procfs_doauxv(struct lwp *, struct proc *, struct pfsnode *,
 int procfs_dolimit(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);
 int procfs_dolimits(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_domq_msg_def(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_domq_msg_max(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_domq_siz_def(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_domq_siz_max(struct lwp *, struct proc *, struct pfsnode *,
+    struct uio *);
+int procfs_domq_qmax(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);
 int procfs_dosysvipc_msg(struct lwp *, struct proc *, struct pfsnode *,
     struct uio *);

--- a/sys/miscfs/procfs/procfs_linux.c
+++ b/sys/miscfs/procfs/procfs_linux.c
@@ -71,6 +71,7 @@ __KERNEL_RCSID(0, "$NetBSD: procfs_linux.c,v 1.88 2024/05/12 17:26:50 christos E
 #ifdef SYSVSHM
 #include <sys/shm.h>
 #endif
+#include <sys/mqueue.h>
 
 #include <miscfs/procfs/procfs.h>
 
@@ -82,6 +83,11 @@ __KERNEL_RCSID(0, "$NetBSD: procfs_linux.c,v 1.88 2024/05/12 17:26:50 christos E
 
 extern struct devsw_conv *devsw_conv;
 extern int max_devsw_convs;
+extern u_int mq_open_max;
+extern u_int mq_max_msgsize;
+extern u_int mq_def_maxmsg;
+extern u_int mq_max_maxmsg;
+
 
 #define PGTOB(p)	((unsigned long)(p) << PAGE_SHIFT)
 #define PGTOKB(p)	((unsigned long)(p) << (PAGE_SHIFT - 10))
@@ -896,4 +902,57 @@ procfs_dosysvipc_shm(struct lwp *curl, struct proc *p,
 out:
 	free(bf, M_TEMP);
 	return error;
+}
+
+static int
+print_uint(unsigned int value, struct uio *uio)
+{
+	char *bf;
+	int offset = 0;
+	int error = EFBIG;
+
+	bf = malloc(LBFSZ, M_TEMP, M_WAITOK);
+	offset += snprintf(bf, LBFSZ, "%u\n", value);
+	if (offset >= LBFSZ)
+		goto out;
+
+	error = uiomove_frombuf(bf, offset, uio);
+out:
+	free(bf, M_TEMP);
+	return error;
+}
+
+int
+procfs_domq_msg_def(struct lwp *curl, struct proc *p,
+    struct pfsnode *pfs, struct uio *uio)
+{
+	return print_uint(mq_def_maxmsg, uio);
+}
+
+int
+procfs_domq_msg_max(struct lwp *curl, struct proc *p,
+    struct pfsnode *pfs, struct uio *uio)
+{
+	return print_uint(mq_max_maxmsg, uio);
+}
+
+int
+procfs_domq_siz_def(struct lwp *curl, struct proc *p,
+    struct pfsnode *pfs, struct uio *uio)
+{
+	return print_uint(MQ_DEF_MSGSIZE, uio);
+}
+
+int
+procfs_domq_siz_max(struct lwp *curl, struct proc *p,
+    struct pfsnode *pfs, struct uio *uio)
+{
+	return print_uint(mq_max_msgsize, uio);
+}
+
+int
+procfs_domq_qmax(struct lwp *curl, struct proc *p,
+    struct pfsnode *pfs, struct uio *uio)
+{
+	return print_uint(mq_open_max, uio);
 }

--- a/sys/miscfs/procfs/procfs_subr.c
+++ b/sys/miscfs/procfs/procfs_subr.c
@@ -299,6 +299,26 @@ procfs_rw(void *v)
 		error = procfs_dosysvipc_shm(curl, p, pfs, uio);
 		break;
 
+	case PFSmq_msg_def:
+		error = procfs_domq_msg_def(curl, p, pfs, uio);
+		break;
+
+	case PFSmq_msg_max:
+		error = procfs_domq_msg_max(curl, p, pfs, uio);
+		break;
+
+	case PFSmq_siz_def:
+		error = procfs_domq_siz_def(curl, p, pfs, uio);
+		break;
+
+	case PFSmq_siz_max:
+		error = procfs_domq_siz_max(curl, p, pfs, uio);
+		break;
+
+	case PFSmq_qmax:
+		error = procfs_domq_qmax(curl, p, pfs, uio);
+		break;
+
 #ifdef __HAVE_PROCFS_MACHDEP
 	PROCFS_MACHDEP_NODETYPE_CASES
 		error = procfs_machdep_rw(curl, l, pfs, uio);

--- a/sys/miscfs/procfs/procfs_vfsops.c
+++ b/sys/miscfs/procfs/procfs_vfsops.c
@@ -437,6 +437,9 @@ procfs_loadvnode(struct mount *mp, struct vnode *vp,
 		vp->v_type = VREG;
 		break;
 
+	case PFSsys:	/* /proc/sys = dr-xr-xr-x */
+	case PFSsysfs:	/* /proc/sys/fs = dr-xr-xr-x */
+	case PFSmqueue:	/* /proc/sys/fs/mqueue = dr-xr-xr-x */
 	case PFSsysvipc:/* /proc/sysvipc = dr-xr-xr-x */
 		if (pfs->pfs_fd == -1) {
 			pfs->pfs_mode = S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP|
@@ -445,6 +448,11 @@ procfs_loadvnode(struct mount *mp, struct vnode *vp,
 			break;
 		}
 		/*FALLTHROUGH*/
+	case PFSmq_msg_def:	/* /proc/sys/fs/mqueue/msg_default = -r--r--r-- */
+	case PFSmq_msg_max:	/* /proc/sys/fs/mqueue/msg_max = -r--r--r-- */
+	case PFSmq_siz_def:	/* /proc/sys/fs/mqueue/msgsize_default = -r--r--r-- */
+	case PFSmq_siz_max:	/* /proc/sys/fs/mqueue/msgsize_max = -r--r--r-- */
+	case PFSmq_qmax:	/* /proc/sys/fs/mqueue/queues_max = -r--r--r-- */
 	case PFSsysvipc_msg:	/* /proc/sysvipc/msg = -r--r--r-- */
 	case PFSsysvipc_sem:	/* /proc/sysvipc/sem = -r--r--r-- */
 	case PFSsysvipc_shm:	/* /proc/sysvipc/shm = -r--r--r-- */

--- a/sys/miscfs/procfs/procfs_vnops.c
+++ b/sys/miscfs/procfs/procfs_vnops.c
@@ -203,11 +203,58 @@ static const struct proc_target proc_root_targets[] = {
 	{ DT_REG, N("stat"),	    PFScpustat,        procfs_validfile_linux },
 	{ DT_REG, N("loadavg"),	    PFSloadavg,        procfs_validfile_linux },
 	{ DT_REG, N("version"),     PFSversion,        procfs_validfile_linux },
+	{ DT_DIR, N("sys"),         PFSsys,            procfs_validfile_linux },
 	{ DT_DIR, N("sysvipc"),     PFSsysvipc,        procfs_validfile_linux },
 #undef N
 };
 static const int nproc_root_targets =
     sizeof(proc_root_targets) / sizeof(proc_root_targets[0]);
+
+/*
+ * List of files in the sys directory
+ */
+static const struct proc_target proc_sys_targets[] = {
+#define N(s) sizeof(s)-1, s
+        /*        name              type            validp */
+	{ DT_DIR, N("."),	PFSsys,		procfs_validfile_linux },
+	{ DT_DIR, N(".."),	PFSroot,	NULL },
+	{ DT_REG, N("fs"),	PFSsysfs,	procfs_validfile_linux },
+#undef N
+};
+static const int nproc_sys_targets =
+    sizeof(proc_sys_targets) / sizeof(proc_sys_targets[0]);
+
+/*
+ * List of files in the sys/fs directory
+ */
+static const struct proc_target proc_sysfs_targets[] = {
+#define N(s) sizeof(s)-1, s
+        /*        name              type            validp */
+	{ DT_DIR, N("."),	PFSsysfs,	procfs_validfile_linux },
+	{ DT_DIR, N(".."),	PFSsys,		procfs_validfile_linux },
+	{ DT_REG, N("mqueue"),	PFSmqueue,	procfs_validfile_linux },
+#undef N
+};
+static const int nproc_sysfs_targets =
+    sizeof(proc_sysfs_targets) / sizeof(proc_sysfs_targets[0]);
+
+/*
+ * List of files in the sys/fs/mqueue directory
+ */
+static const struct proc_target proc_mqueue_targets[] = {
+#define N(s) sizeof(s)-1, s
+        /*        name              	type            validp */
+	{ DT_DIR, N("."),		PFSmqueue,	procfs_validfile_linux },
+	{ DT_DIR, N(".."),		PFSsysfs,	procfs_validfile_linux },
+	{ DT_REG, N("msg_default"),	PFSmq_msg_def,	procfs_validfile_linux },
+	{ DT_REG, N("msg_max"),		PFSmq_msg_max,	procfs_validfile_linux },
+	{ DT_REG, N("msgsize_default"),	PFSmq_siz_def,	procfs_validfile_linux },
+	{ DT_REG, N("msgsize_max"),	PFSmq_siz_max,	procfs_validfile_linux },
+	{ DT_REG, N("queues_max"),	PFSmq_qmax,	procfs_validfile_linux },
+#undef N
+};
+static const int nproc_mqueue_targets =
+    sizeof(proc_mqueue_targets) / sizeof(proc_mqueue_targets[0]);
 
 /*
  * List of files in the sysvipc directory
@@ -742,6 +789,11 @@ procfs_getattr(void *v)
 	case PFSself:
 	case PFScurproc:
 	case PFSroot:
+	case PFSmq_msg_def:
+	case PFSmq_msg_max:
+	case PFSmq_siz_def:
+	case PFSmq_siz_max:
+	case PFSmq_qmax:
 	case PFSsysvipc_msg:
 	case PFSsysvipc_sem:
 	case PFSsysvipc_shm:
@@ -751,6 +803,17 @@ procfs_getattr(void *v)
 
 	case PFSsysvipc:
 		vap->va_nlink = 5;
+		vap->va_uid = vap->va_gid = 0;
+		break;
+
+	case PFSsys:	/* proc/sys only contains "fs" */
+	case PFSsysfs:	/* proc/sys/fs only contains "mqueue" */
+		vap->va_nlink = 3;
+		vap->va_uid = vap->va_gid = 0;
+		break;
+
+	case PFSmqueue:
+		vap->va_nlink = 7;
 		vap->va_uid = vap->va_gid = 0;
 		break;
 
@@ -868,6 +931,14 @@ procfs_getattr(void *v)
 	case PFSloadavg:
 	case PFSstatm:
 	case PFSversion:
+	case PFSsys:
+	case PFSsysfs:
+	case PFSmqueue:
+	case PFSmq_msg_def:
+	case PFSmq_msg_max:
+	case PFSmq_siz_def:
+	case PFSmq_siz_max:
+	case PFSmq_qmax:
 	case PFSsysvipc:
 	case PFSsysvipc_msg:
 	case PFSsysvipc_sem:
@@ -1188,15 +1259,47 @@ procfs_lookup(void *v)
 		procfs_proc_unlock(p);
 		return error;
 	}
-	case PFSsysvipc:
+	case PFSsys:
+	case PFSsysfs:
+	case PFSmqueue:
+	case PFSsysvipc: {
+		const struct proc_target *targets;
+		int ntargets;
+		pfstype parent;
+
+		switch (pfs->pfs_type) {
+		case PFSsys:
+			targets = proc_sys_targets;
+			ntargets = nproc_sys_targets;
+			parent = PFSroot;
+			break;
+		case PFSsysfs:
+			targets = proc_sysfs_targets;
+			ntargets = nproc_sysfs_targets;
+			parent = PFSsys;
+			break;
+		case PFSmqueue:
+			targets = proc_mqueue_targets;
+			ntargets = nproc_mqueue_targets;
+			parent = PFSsysfs;
+			break;
+		case PFSsysvipc:
+			targets = proc_sysvipc_targets;
+			ntargets = nproc_sysvipc_targets;
+			parent = PFSroot;
+			break;
+		default:
+			return (EINVAL);
+		}
+
 		if (cnp->cn_flags & ISDOTDOT) {
-			error = procfs_allocvp(dvp->v_mount, vpp, 0, PFSroot,
+			error = procfs_allocvp(dvp->v_mount, vpp, 0, parent,
 			    -1);
 			return (error);
 		}
 
-		for (i = 0; i < nproc_sysvipc_targets; i++) {
-			pt = &proc_sysvipc_targets[i];
+		for (i = 0; i < ntargets; i++) {
+			pt = &targets[i];
 			/*
 			 * check for node match.  proc is always NULL here,
 			 * so call pt_valid with constant NULL lwp.
@@ -1208,13 +1311,14 @@ procfs_lookup(void *v)
 				break;
 		}
 
-		if (i != nproc_sysvipc_targets) {
+		if (i != ntargets) {
 			error = procfs_allocvp(dvp->v_mount, vpp, 0,
 			    pt->pt_pfstype, -1);
 			return (error);
 		}
 
 		return (ENOENT);
+	}
 
 	default:
 		return (ENOTDIR);
@@ -1502,21 +1606,48 @@ procfs_readdir(void *v)
 	}
 
 	/*
-	 * sysvipc subdirectory
+	 * misc subdirectories
 	 */
+	case PFSsys:
+	case PFSsysfs:
+	case PFSmqueue:
 	case PFSsysvipc: {
+		const struct proc_target *targets;
+		int ntargets;
+
+		switch (pfs->pfs_type) {
+		case PFSsys:
+			targets = proc_sys_targets;
+			ntargets = nproc_sys_targets;
+			break;
+		case PFSsysfs:
+			targets = proc_sysfs_targets;
+			ntargets = nproc_sysfs_targets;
+			break;
+		case PFSmqueue:
+			targets = proc_mqueue_targets;
+			ntargets = nproc_mqueue_targets;
+			break;
+		case PFSsysvipc:
+			targets = proc_sysvipc_targets;
+			ntargets = nproc_sysvipc_targets;
+			break;
+		default:
+			return (EINVAL);
+		}
+
 		if ((error = procfs_proc_lock(vp->v_mount, pfs->pfs_pid, &p,
 					      ESRCH)) != 0)
 			return error;
 		if (ap->a_ncookies) {
-			ncookies = uimin(ncookies, (nproc_sysvipc_targets - i));
+			ncookies = uimin(ncookies, (ntargets - i));
 			cookies = malloc(ncookies * sizeof (off_t),
 			    M_TEMP, M_WAITOK);
 			*ap->a_cookies = cookies;
 		}
 
-		for (pt = &proc_sysvipc_targets[i];
-		     uio->uio_resid >= UIO_MX && i < nproc_sysvipc_targets; pt++, i++) {
+		for (pt = &targets[i];
+		     uio->uio_resid >= UIO_MX && i < ntargets; pt++, i++) {
 			if (pt->pt_valid &&
 			    (*pt->pt_valid)(NULL, vp->v_mount) == 0)
 				continue;

--- a/sys/modules/compat_linux/Makefile
+++ b/sys/modules/compat_linux/Makefile
@@ -13,7 +13,7 @@ SRCS+=	linux_fdio.c linux_file.c linux_hdio.c linux_ioctl.c
 SRCS+=	linux_ipc.c linux_misc.c linux_mtio.c linux_sched.c
 SRCS+=	linux_sg.c linux_signal.c linux_signo.c linux_socket.c
 SRCS+=	linux_sysctl.c linux_termios.c linux_time.c linux_mod.c
-SRCS+=	linux_inotify.c
+SRCS+=	linux_inotify.c linux_mqueue.c
 
 .if ${MACHINE_CPU} == "aarch64"
 CPPFLAGS+=	-DEXEC_ELF64


### PR DESCRIPTION
Support POSIX message queues.

Ref: kern/58287

Notes:
- Tested only on amd64
- 2nd commit was generated by `make linux_sysent.c` in each arch subdirectory in sys/compat/linux/arch

To test (on kernel with `no file-system PROCFS` & `no options MQUEUE`):
 ```
cd /usr/src
./build.sh -j8 -O /usr/obj -T /usr/tools modules
doas ./build.sh -j8 -O /usr/obj -T /usr/tools installmodules=/

# OR

doas umount -a -t procfs
for m in mqueue compat_linux procfs ; do \
cd /usr/src/sys/modules/
make
doas cp -f $m.kmod /stand/$(uname -m)/$(uname -r)/modules/$m/
doas modunload $m
doas modload $m
done
```