### PR TITLE
[libedit] Register signal handler with SA_ONSTACK flag.

### DIFF
--- a/lib/libedit/sig.c
+++ b/lib/libedit/sig.c
@@ -167,7 +167,7 @@ sig_set(EditLine *el)
 	struct sigaction osa, nsa;
 
 	nsa.sa_handler = sig_handler;
-	nsa.sa_flags = 0;
+	nsa.sa_flags = SA_ONSTACK;
 	sigemptyset(&nsa.sa_mask);
 
 	sel = el;


### PR DESCRIPTION
This allows the handler to use the alternate signal stack if one is available in the handling thread, but has no effect otherwise.

This change makes the signal handler respect existing choices better. Specifically, this allows signal handlers to be set when the process includes a Go runtime, since Go enforces that _all_ signal handlers in the process use the SA_ONSTACK flag (e.g. see https://github.com/golang/go/issues/20400).