### PR TITLE
Add close_range() system call

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -338,6 +338,7 @@ int	 pipe2(int *, int);
 #if defined(_NETBSD_SOURCE)
 int	 acct(const char *);
 int	 closefrom(int);
+int	 close_range(unsigned int, unsigned int, int);
 int	 des_cipher(const char *, char *, long, int);
 int	 des_setkey(const char *);
 void	 endusershell(void);

--- a/lib/libc/sys/Makefile.inc
+++ b/lib/libc/sys/Makefile.inc
@@ -102,6 +102,7 @@ ASM=\
 	chdir.S chflags.S chmod.S chown.S chroot.S \
 		clock_getcpuclockid2.S \
 		__clock_getres50.S __clock_gettime50.S \
+	close_range.S \
 	dup.S dup2.S __dup3100.S \
 	eventfd.S \
 	extattrctl.S \

--- a/lib/libc/sys/close_range.2
+++ b/lib/libc/sys/close_range.2
@@ -1,0 +1,62 @@
+.Dd Jul 19, 2025
+.Dt CLOSE_RANGE 2
+.Os
+.Sh NAME
+.Nm close_range
+.Nd delete open file descriptors
+.Sh LIBRARY
+.Lb libc
+.Sh SYNOPSIS
+.In unistd.h
+.Ft int
+.Fn close_range "u_int first" "u_int last" "int flags"
+.Sh DESCRIPTION
+The
+.Fn close_range
+system call deletes all open file descriptors between
+.Fa first
+and
+.Fa last
+inclusive, clamped to the range of open file descriptors.
+Any errors encountered while closing file descriptors are ignored.
+Supported
+.Fa flags :
+.Bl -tag -width ".Dv CLOSE_RANGE_CLOEXEC"
+.It Dv CLOSE_RANGE_CLOEXEC
+Set the close-on-exec flag on descriptors in the range instead of closing them.
+.It Dv CLOSE_RANGE_CLOFORK
+Set the close-on-fork flag on descriptors in the range instead of closing them.
+.El
+.Sh RETURN VALUES
+Upon successful completion,
+.Fn close_range
+returns a value
+of 0.
+Otherwise, a value of -1 is returned and the global variable
+.Va errno
+is set to indicate the error.
+.Sh ERRORS
+The
+.Fn close_range
+system call
+will fail if:
+.Bl -tag -width Er
+.It Bq Er EINVAL
+The
+.Fa last
+argument is lower than the
+.Fa first
+argument.
+.It Bq Er EINVAL
+An invalid flag was set.
+.El
+.Sh SEE ALSO
+.Xr close 2
+.Xr closefrom 3
+.Sh HISTORY
+The
+.Fn close_range
+function comes from Linux and first appeared in
+.Fx 8.0
+and
+.Nx 11.0 .

--- a/sys/compat/linux/common/linux_misc.c
+++ b/sys/compat/linux/common/linux_misc.c
@@ -2062,7 +2062,6 @@ linux_sys_memfd_create(struct lwp *l,
 	return sys_memfd_create(l, &muap, retval);
 }
 
-#define	LINUX_CLOSE_RANGE_UNSHARE	0x02U
 #define	LINUX_CLOSE_RANGE_CLOEXEC	0x04U
 
 /*
@@ -2077,37 +2076,17 @@ linux_sys_close_range(struct lwp *l,
 		syscallarg(unsigned int) last;
 		syscallarg(unsigned int) flags;
 	} */
-	unsigned int fd, last;
-	file_t *fp;
-	filedesc_t *fdp;
-	const unsigned int flags = SCARG(uap, flags);
+	struct sys_close_range_args crap;
+	const unsigned int lflags = SCARG(uap, flags);
+	int flags = 0;
 
-	if (flags & ~(LINUX_CLOSE_RANGE_CLOEXEC|LINUX_CLOSE_RANGE_UNSHARE))
+	if (lflags & ~LINUX_CLOSE_RANGE_CLOEXEC)
 		return EINVAL;
-	if (SCARG(uap, first) > SCARG(uap, last))
-		return EINVAL;
+	if (lflags & LINUX_CLOSE_RANGE_CLOEXEC)
+		flags |= CLOSE_RANGE_CLOEXEC;
+	SCARG(&crap, flags) = flags;
 
-	if (flags & LINUX_CLOSE_RANGE_UNSHARE) {
-		fdp = fd_copy();
-		fd_free();
-	        l->l_proc->p_fd = fdp;
-	        l->l_fd = fdp;
-	}
-
-	last = MIN(SCARG(uap, last), l->l_proc->p_fd->fd_lastfile);
-	for (fd = SCARG(uap, first); fd <= last; fd++) {
-		fp = fd_getfile(fd);
-		if (fp == NULL)
-			continue;
-
-		if (flags & LINUX_CLOSE_RANGE_CLOEXEC) {
-			fd_set_exclose(l, fd, true);
-			fd_putfile(fd);
-		} else
-			fd_close(fd);
-	}
-
-	return 0;
+	return sys_close_range(l, &crap, retval);
 }
 
 /*

--- a/sys/kern/init_sysent.c
+++ b/sys/kern/init_sysent.c
@@ -1,4 +1,4 @@
-/* $NetBSD: init_sysent.c,v 1.346 2024/10/09 16:29:10 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call switch table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: init_sysent.c,v 1.346 2024/10/09 16:29:10 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #ifdef _KERNEL_OPT
 #include "opt_modular.h"
@@ -2483,8 +2483,9 @@ struct sysent sysent[] = {
 		.sy_call = (sy_call_t *)sys_nomodule
 	},		/* 506 = semtimedop */
 	{
-		.sy_call = sys_nosys,
-	},		/* 507 = filler */
+		ns(struct sys_close_range_args),
+		.sy_call = (sy_call_t *)sys_close_range
+	},		/* 507 = close_range */
 	{
 		.sy_call = sys_nosys,
 	},		/* 508 = filler */

--- a/sys/kern/sys_descrip.c
+++ b/sys/kern/sys_descrip.c
@@ -741,3 +741,38 @@ sys_pipe2(struct lwp *l, const struct sys_pipe2_args *uap, register_t *retval)
 	retval[0] = 0;
 	return 0;
 }
+
+int
+sys_close_range(struct lwp *l, const struct sys_close_range_args *uap, register_t *retval)
+{
+	/* {
+		syscallarg(unsigned int) first;
+		syscallarg(unsigned int) last;
+		syscallarg(int) flags;
+	} */
+	const unsigned int flags = SCARG(uap, flags);
+	unsigned int fd, last;
+	file_t *fp;
+
+	if (flags & ~(CLOSE_RANGE_CLOEXEC|CLOSE_RANGE_CLOFORK))
+		return EINVAL;
+
+	if (SCARG(uap, first) > SCARG(uap, last))
+		return EINVAL;
+
+	last = MIN(SCARG(uap, last), l->l_proc->p_fd->fd_lastfile);
+	for (fd = SCARG(uap, first); fd <= last; fd++) {
+		fp = fd_getfile(fd);
+		if (fp == NULL)
+			continue;
+
+		if (flags != 0) {
+			fd_set_exclose(l, fd, (flags & CLOSE_RANGE_CLOEXEC) != 0);
+			fd_set_foclose(l, fd, (flags & CLOSE_RANGE_CLOFORK) != 0);
+			fd_putfile(fd);
+		} else
+			fd_close(fd);
+	}
+
+	return 0;
+}

--- a/sys/kern/syscalls.c
+++ b/sys/kern/syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: syscalls.c,v 1.334 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call names.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: syscalls.c,v 1.334 2024/10/09 16:29:11 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #if defined(_KERNEL_OPT)
 #ifdef _KERNEL_OPT
@@ -557,7 +557,7 @@ const char *const syscallnames[] = {
 	/* 504 */	"epoll_pwait2",
 	/* 505 */	"__dup3100",
 	/* 506 */	"semtimedop",
-	/* 507 */	"# filler",
+	/* 507 */	"close_range",
 	/* 508 */	"# filler",
 	/* 509 */	"# filler",
 	/* 510 */	"# filler",
@@ -1094,7 +1094,7 @@ const char *const altsyscallnames[] = {
 	/* 504 */	NULL, /* epoll_pwait2 */
 	/* 505 */	"dup3",
 	/* 506 */	NULL, /* semtimedop */
-	/* 507 */	NULL, /* filler */
+	/* 507 */	NULL, /* close_range */
 	/* 508 */	NULL, /* filler */
 	/* 509 */	NULL, /* filler */
 	/* 510 */	NULL, /* filler */

--- a/sys/kern/syscalls.master
+++ b/sys/kern/syscalls.master
@@ -1068,3 +1068,5 @@
 506	STD MODULAR sysv_ipc { int|sys||semtimedop(int semid, \
 			    struct sembuf *sops, size_t nsops, \
 			    struct timespec *timeout); }
+507	STD		{ int|sys||close_range(u_int first, u_int last, \
+			    int flags); }

--- a/sys/kern/syscalls_autoload.c
+++ b/sys/kern/syscalls_autoload.c
@@ -1,4 +1,4 @@
-/* $NetBSD: syscalls_autoload.c,v 1.50 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call autoload table.
@@ -8,7 +8,7 @@
  */
 
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: syscalls_autoload.c,v 1.50 2024/10/09 16:29:11 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #ifdef _KERNEL_OPT
 #include "opt_modular.h"

--- a/sys/kern/systrace_args.c
+++ b/sys/kern/systrace_args.c
@@ -1,4 +1,4 @@
-/* $NetBSD: systrace_args.c,v 1.56 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument to DTrace register array conversion.
@@ -3952,6 +3952,15 @@ systrace_args(register_t sysnum, const void *params, uintptr_t *uarg, size_t *n_
 		uarg[2] = SCARG(p, nsops); /* size_t */
 		uarg[3] = (intptr_t) SCARG(p, timeout); /* struct timespec * */
 		*n_args = 4;
+		break;
+	}
+	/* sys_close_range */
+	case 507: {
+		const struct sys_close_range_args *p = params;
+		uarg[0] = SCARG(p, first); /* u_int */
+		uarg[1] = SCARG(p, last); /* u_int */
+		iarg[2] = SCARG(p, flags); /* int */
+		*n_args = 3;
 		break;
 	}
 	default:
@@ -10683,6 +10692,22 @@ systrace_entry_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 			break;
 		};
 		break;
+	/* sys_close_range */
+	case 507:
+		switch(ndx) {
+		case 0:
+			p = "u_int";
+			break;
+		case 1:
+			p = "u_int";
+			break;
+		case 2:
+			p = "int";
+			break;
+		default:
+			break;
+		};
+		break;
 	default:
 		break;
 	};
@@ -12917,6 +12942,11 @@ systrace_return_setargdesc(int sysnum, int ndx, char *desc, size_t descsz)
 		break;
 	/* sys_semtimedop */
 	case 506:
+		if (ndx == 0 || ndx == 1)
+			p = "int";
+		break;
+	/* sys_close_range */
+	case 507:
 		if (ndx == 0 || ndx == 1)
 			p = "int";
 		break;

--- a/sys/rump/include/rump/rump_syscalls.h
+++ b/sys/rump/include/rump/rump_syscalls.h
@@ -1,4 +1,4 @@
-/* $NetBSD: rump_syscalls.h,v 1.133 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call protos in rump namespace.

--- a/sys/rump/librump/rumpkern/rump_syscalls.c
+++ b/sys/rump/librump/rumpkern/rump_syscalls.c
@@ -1,4 +1,4 @@
-/* $NetBSD: rump_syscalls.c,v 1.164 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call vector and marshalling for rump.
@@ -15,7 +15,7 @@
 
 #ifdef __NetBSD__
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: rump_syscalls.c,v 1.164 2024/10/09 16:29:11 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/fstypes.h>
 #include <sys/proc.h>
@@ -8664,9 +8664,8 @@ struct sysent rump_sysent[] = {
 		.sy_call = (sy_call_t *)(void *)rumpns_sys_nomodule,
 },		/* 506 = semtimedop */
 	{
-		.sy_flags = SYCALL_NOSYS,
 		.sy_call = (sy_call_t *)(void *)rumpns_enosys,
-	},		/* 507 = filler */
+},		/* 507 = close_range */
 	{
 		.sy_flags = SYCALL_NOSYS,
 		.sy_call = (sy_call_t *)(void *)rumpns_enosys,

--- a/sys/sys/syscall.h
+++ b/sys/sys/syscall.h
@@ -1,4 +1,4 @@
-/* $NetBSD: syscall.h,v 1.329 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call numbers.
@@ -1425,6 +1425,9 @@
 /* syscall: "semtimedop" ret: "int" args: "int" "struct sembuf *" "size_t" "struct timespec *" */
 #define	SYS_semtimedop	506
 
-#define	SYS_MAXSYSCALL	507
+/* syscall: "close_range" ret: "int" args: "u_int" "u_int" "int" */
+#define	SYS_close_range	507
+
+#define	SYS_MAXSYSCALL	508
 #define	SYS_NSYSENT	512
 #endif /* _SYS_SYSCALL_H_ */

--- a/sys/sys/syscallargs.h
+++ b/sys/sys/syscallargs.h
@@ -1,4 +1,4 @@
-/* $NetBSD: syscallargs.h,v 1.312 2024/10/09 16:29:11 christos Exp $ */
+/* $NetBSD$ */
 
 /*
  * System call argument lists.
@@ -3419,6 +3419,15 @@ struct sys_semtimedop_args {
 check_syscall_args(sys_semtimedop)
 #endif /* !RUMP_CLIENT */
 
+#ifndef RUMP_CLIENT
+struct sys_close_range_args {
+	syscallarg(u_int) first;
+	syscallarg(u_int) last;
+	syscallarg(int) flags;
+};
+check_syscall_args(sys_close_range)
+#endif /* !RUMP_CLIENT */
+
 /*
  * System call prototypes.
  */
@@ -4356,6 +4365,8 @@ int	sys_epoll_pwait2(struct lwp *, const struct sys_epoll_pwait2_args *, registe
 int	sys___dup3100(struct lwp *, const struct sys___dup3100_args *, register_t *);
 
 int	sys_semtimedop(struct lwp *, const struct sys_semtimedop_args *, register_t *);
+
+int	sys_close_range(struct lwp *, const struct sys_close_range_args *, register_t *);
 
 #endif /* !RUMP_CLIENT */
 #endif /* _SYS_SYSCALLARGS_H_ */

--- a/sys/sys/unistd.h
+++ b/sys/sys/unistd.h
@@ -344,4 +344,12 @@
 /* configurable system strings */
 #define	_CS_PATH			   1
 
+/*
+ * close_range(2) options
+ */
+#ifdef _NETBSD_SOURCE
+#define CLOSE_RANGE_CLOEXEC	(1<<2)
+#define CLOSE_RANGE_CLOFORK	(1<<3)
+#endif
+
 #endif /* !_SYS_UNISTD_H_ */

--- a/tests/lib/libc/sys/Makefile
+++ b/tests/lib/libc/sys/Makefile
@@ -14,6 +14,7 @@ TESTS_C+=		t_chroot
 TESTS_C+=		t_clock_gettime
 TESTS_C+=		t_clock_nanosleep
 TESTS_C+=		t_clone
+TESTS_C+=		t_close_range
 TESTS_C+=		t_connect
 TESTS_C+=		t_dup
 TESTS_C+=		t_eventfd

--- a/tests/lib/libc/sys/t_close_range.c
+++ b/tests/lib/libc/sys/t_close_range.c
@@ -1,0 +1,275 @@
+/*-
+ * Copyright (c) 2011 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Jukka Ruohonen.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sys/cdefs.h>
+
+#include <sys/wait.h>
+
+#include <atf-c.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <unistd.h>
+
+static const char  path[] = "close_range";
+
+ATF_TC_WITH_CLEANUP(close_range_basic);
+ATF_TC_HEAD(close_range_basic, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "A basic test of close_range(2), #1");
+}
+
+ATF_TC_BODY(close_range_basic, tc)
+{
+	int fd, cur1, cur2;
+
+	(void)close_range(STDERR_FILENO + 1, UINT_MAX, 0);
+
+	fd = open(path, O_RDONLY | O_CREAT, 0400);
+	ATF_REQUIRE(fd >= 0);
+
+	cur1 = fcntl(0, F_MAXFD);
+
+	ATF_REQUIRE(cur1 == STDERR_FILENO + 1);
+	ATF_REQUIRE(close_range(cur1, UINT_MAX, 0) == 0);
+
+	cur2 = fcntl(0, F_MAXFD);
+
+	ATF_REQUIRE(cur1 - 1 == cur2);
+	ATF_REQUIRE(close(fd) == -1);
+	ATF_REQUIRE(unlink(path) == 0);
+}
+
+ATF_TC_CLEANUP(close_range_basic, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC_WITH_CLEANUP(close_range_buffer);
+ATF_TC_HEAD(close_range_buffer, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "A basic test of close_range(2), #2");
+}
+
+ATF_TC_BODY(close_range_buffer, tc)
+{
+	int buf[16], cur, half;
+	size_t i;
+
+	/*
+	 * Open a buffer of descriptors, close the half of
+	 * these and verify that the result is consistent.
+	 */
+	ATF_REQUIRE(close_range(STDERR_FILENO + 1, UINT_MAX, 0) == 0);
+
+	cur = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur == STDERR_FILENO);
+
+	for (i = 0; i < __arraycount(buf); i++) {
+		buf[i] = open(path, O_RDWR | O_CREAT, 0600);
+		ATF_REQUIRE(buf[i] >= 0);
+	}
+
+	cur = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur == __arraycount(buf) + STDERR_FILENO);
+
+	half = STDERR_FILENO + __arraycount(buf) / 2;
+	ATF_REQUIRE(close_range(half, UINT_MAX, 0) == 0);
+
+	cur = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur == half - 1);
+
+	for (i = 0; i < __arraycount(buf); i++)
+		(void)close(buf[i]);
+}
+
+ATF_TC_CLEANUP(close_range_buffer, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC(close_range_err);
+ATF_TC_HEAD(close_range_err, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test errors from close_range(2)");
+}
+
+ATF_TC_BODY(close_range_err, tc)
+{
+
+	errno = 0;
+	ATF_REQUIRE_ERRNO(EINVAL, close_range(UINT_MAX, 0, 0) == -1);
+}
+
+ATF_TC(close_range_one);
+ATF_TC_HEAD(close_range_one, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(1, UINT_MAX, 0)");
+}
+
+ATF_TC_BODY(close_range_one, tc)
+{
+	pid_t pid;
+	int sta;
+
+	pid = fork();
+	ATF_REQUIRE(pid >= 0);
+
+	if (pid == 0) {
+
+		if (close_range(1, UINT_MAX, 0) != 0)
+			_exit(10);
+
+		_exit(fcntl(0, F_MAXFD));
+	}
+
+
+	(void)wait(&sta);
+
+	/*
+	 * STDIN_FILENO should still be open; WEXITSTATUS(1) == 0.
+	 */
+	if (WIFEXITED(sta) == 0 || WEXITSTATUS(sta) != 0)
+		atf_tc_fail("not all descriptors were closed");
+}
+
+ATF_TC_WITH_CLEANUP(close_range_cloexec);
+ATF_TC_HEAD(close_range_cloexec, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(2) with CLOSE_RANGE_CLOEXEC");
+}
+
+ATF_TC_BODY(close_range_cloexec, tc)
+{
+	int fd, cur1, cur2;
+	int flags;
+
+	fd = open(path, O_RDONLY | O_CREAT, 0400);
+	ATF_REQUIRE(fd >= 0);
+
+	flags = fcntl(fd, F_GETFD);
+	ATF_REQUIRE(flags != -1);
+	ATF_REQUIRE(fcntl(fd, F_SETFD, flags | FD_CLOEXEC) != -1);
+
+	cur1 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == STDERR_FILENO + 1);
+	ATF_REQUIRE(close_range(cur1, UINT_MAX, CLOSE_RANGE_CLOEXEC) == 0);
+
+	cur2 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == cur2);
+
+	flags = fcntl(fd, F_GETFD);
+	ATF_REQUIRE(flags != -1);
+	ATF_CHECK((flags & FD_CLOEXEC) != 0);
+
+	ATF_REQUIRE(close(fd) == 0);
+	ATF_REQUIRE(unlink(path) == 0);
+}
+
+ATF_TC_CLEANUP(close_range_cloexec, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC_WITH_CLEANUP(close_range_invalid_flag);
+ATF_TC_HEAD(close_range_invalid_flag, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(2) with an invalid flag");
+}
+
+ATF_TC_BODY(close_range_invalid_flag, tc)
+{
+	int cur1, cur2;
+	int unused_flag = 0x40000000;
+
+	cur1 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == STDERR_FILENO);
+
+	errno = 0;
+	ATF_REQUIRE_ERRNO(EINVAL, close_range(STDERR_FILENO + 1, UINT_MAX, unused_flag) == -1);
+
+	cur2 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == cur2);
+}
+
+ATF_TC_CLEANUP(close_range_invalid_flag, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC_WITH_CLEANUP(close_range_above);
+ATF_TC_HEAD(close_range_above, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(2) doesn't close above a limit");
+}
+
+ATF_TC_BODY(close_range_above, tc)
+{
+	int fd, fd2;
+	int cur1, cur2;
+
+	fd = open(path, O_RDONLY | O_CREAT, 0400);
+	ATF_REQUIRE(fd >= 0);
+
+	fd2 = dup2(fd, 777);
+	ATF_REQUIRE(fd2 == 777);
+
+	cur1 = fcntl(0, F_MAXFD);
+
+	ATF_REQUIRE(close_range(fd + 1, fd2 - 1, 0) == 0);
+
+	cur2 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == cur2);
+
+	ATF_REQUIRE(fcntl(fd, F_GETFD) != -1);
+	ATF_REQUIRE(close(fd) == 0);
+
+	ATF_REQUIRE(fcntl(fd2, F_GETFD) != -1);
+	ATF_REQUIRE(close(fd2) == 0);
+
+	ATF_REQUIRE(unlink(path) == 0);
+}
+
+ATF_TC_CLEANUP(close_range_above, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+
+	ATF_TP_ADD_TC(tp, close_range_basic);
+	ATF_TP_ADD_TC(tp, close_range_buffer);
+	ATF_TP_ADD_TC(tp, close_range_err);
+	ATF_TP_ADD_TC(tp, close_range_one);
+	ATF_TP_ADD_TC(tp, close_range_cloexec);
+	ATF_TP_ADD_TC(tp, close_range_invalid_flag);
+	ATF_TP_ADD_TC(tp, close_range_above);
+
+	return atf_no_error();
+}


### PR DESCRIPTION
Adapt existing code in `compat_linux` for `close_range` and make it use the new native system call.

The existing test code for `closefrom(3)` was adapted and extended for `close_range(2)`.

The manpage was adapted from FreeBSD using the Linux names for the parameters:
https://man.freebsd.org/cgi/man.cgi?query=close_range&sektion=2&n=1

Fixes [kern/59081](https://gnats.netbsd.org/59081)

`CLOSE_RANGE_UNSHARE` was removed as it doesn't make sense on NetBSD which lacks `unshare(2)`. From the [Linux documentation](https://man7.org/linux/man-pages/man2/close_range.2.html):

```
       CLOSE_RANGE_UNSHARE is conceptually equivalent to
           unshare(CLONE_FILES);
           close_range(first, last, 0);
```