### PR TITLE
sys/external/bsd/drm2/dist/drm/i915 subdirectory: Linux 5.6.19 merge

### DIFF
--- a/sys/external/bsd/drm2/dist/drm/i915/Kconfig.profile
+++ b/sys/external/bsd/drm2/dist/drm/i915/Kconfig.profile
@@ -35,6 +35,10 @@ config DRM_I915_PREEMPT_TIMEOUT
 
 	  May be 0 to disable the timeout.
 
+	  The compiled in default may get overridden at driver probe time on
+	  certain platforms and certain engines which will be reflected in the
+	  sysfs control.
+
 config DRM_I915_SPIN_REQUEST
 	int "Busywait for request completion (us)"
 	default 5 # microseconds

--- a/sys/external/bsd/drm2/dist/drm/i915/display/intel_ddi.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/display/intel_ddi.c
@@ -2230,7 +2230,11 @@ static void intel_ddi_get_power_domains(struct intel_encoder *encoder,
 		return;
 
 	dig_port = enc_to_dig_port(encoder);
-	intel_display_power_get(dev_priv, dig_port->ddi_io_power_domain);
+
+	if (!intel_phy_is_tc(dev_priv, phy) ||
+	    dig_port->tc_mode != TC_PORT_TBT_ALT)
+		intel_display_power_get(dev_priv,
+					dig_port->ddi_io_power_domain);
 
 	/*
 	 * AUX power is only needed for (e)DP mode, and for HDMI mode on TC
@@ -3546,9 +3550,6 @@ static void hsw_ddi_pre_enable_dp(struct intel_encoder *encoder,
 	intel_dp_set_link_params(intel_dp, crtc_state->port_clock,
 				 crtc_state->lane_count, is_mst);
 
-	intel_dp->regs.dp_tp_ctl = DP_TP_CTL(port);
-	intel_dp->regs.dp_tp_status = DP_TP_STATUS(port);
-
 	intel_edp_panel_on(intel_dp);
 
 	intel_ddi_clk_select(encoder, crtc_state);
@@ -4270,11 +4271,17 @@ void intel_ddi_get_config(struct intel_encoder *encoder,
 	struct drm_i915_private *dev_priv = to_i915(encoder->base.dev);
 	struct intel_crtc *intel_crtc = to_intel_crtc(pipe_config->uapi.crtc);
 	enum transcoder cpu_transcoder = pipe_config->cpu_transcoder;
+	struct intel_dp *intel_dp = enc_to_intel_dp(encoder);
 	u32 temp, flags = 0;
 
 	/* XXX: DSI transcoder paranoia */
 	if (WARN_ON(transcoder_is_dsi(cpu_transcoder)))
 		return;
+
+	if (INTEL_GEN(dev_priv) >= 12) {
+		intel_dp->regs.dp_tp_ctl = TGL_DP_TP_CTL(cpu_transcoder);
+		intel_dp->regs.dp_tp_status = TGL_DP_TP_STATUS(cpu_transcoder);
+	}
 
 	intel_dsc_get_config(encoder, pipe_config);
 
@@ -4493,6 +4500,7 @@ static const struct drm_encoder_funcs intel_ddi_funcs = {
 static struct intel_connector *
 intel_ddi_init_dp_connector(struct intel_digital_port *intel_dig_port)
 {
+	struct drm_i915_private *dev_priv = to_i915(intel_dig_port->base.base.dev);
 	struct intel_connector *connector;
 	enum port port = intel_dig_port->base.port;
 
@@ -4503,6 +4511,10 @@ intel_ddi_init_dp_connector(struct intel_digital_port *intel_dig_port)
 	intel_dig_port->dp.output_reg = DDI_BUF_CTL(port);
 	intel_dig_port->dp.prepare_link_retrain =
 		intel_ddi_prepare_link_retrain;
+	if (INTEL_GEN(dev_priv) < 12) {
+		intel_dig_port->dp.regs.dp_tp_ctl = DP_TP_CTL(port);
+		intel_dig_port->dp.regs.dp_tp_status = DP_TP_STATUS(port);
+	}
 
 	if (!intel_dp_init_connector(intel_dig_port, connector)) {
 		kfree(connector);

--- a/sys/external/bsd/drm2/dist/drm/i915/display/intel_display_power.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/display/intel_display_power.c
@@ -4081,7 +4081,7 @@ static const struct i915_power_well_desc tgl_power_wells[] = {
 	{
 		.name = "AUX D TBT1",
 		.domains = TGL_AUX_D_TBT1_IO_POWER_DOMAINS,
-		.ops = &hsw_power_well_ops,
+		.ops = &icl_tc_phy_aux_power_well_ops,
 		.id = DISP_PW_ID_NONE,
 		{
 			.hsw.regs = &icl_aux_power_well_regs,
@@ -4092,7 +4092,7 @@ static const struct i915_power_well_desc tgl_power_wells[] = {
 	{
 		.name = "AUX E TBT2",
 		.domains = TGL_AUX_E_TBT2_IO_POWER_DOMAINS,
-		.ops = &hsw_power_well_ops,
+		.ops = &icl_tc_phy_aux_power_well_ops,
 		.id = DISP_PW_ID_NONE,
 		{
 			.hsw.regs = &icl_aux_power_well_regs,
@@ -4103,7 +4103,7 @@ static const struct i915_power_well_desc tgl_power_wells[] = {
 	{
 		.name = "AUX F TBT3",
 		.domains = TGL_AUX_F_TBT3_IO_POWER_DOMAINS,
-		.ops = &hsw_power_well_ops,
+		.ops = &icl_tc_phy_aux_power_well_ops,
 		.id = DISP_PW_ID_NONE,
 		{
 			.hsw.regs = &icl_aux_power_well_regs,
@@ -4114,7 +4114,7 @@ static const struct i915_power_well_desc tgl_power_wells[] = {
 	{
 		.name = "AUX G TBT4",
 		.domains = TGL_AUX_G_TBT4_IO_POWER_DOMAINS,
-		.ops = &hsw_power_well_ops,
+		.ops = &icl_tc_phy_aux_power_well_ops,
 		.id = DISP_PW_ID_NONE,
 		{
 			.hsw.regs = &icl_aux_power_well_regs,
@@ -4125,7 +4125,7 @@ static const struct i915_power_well_desc tgl_power_wells[] = {
 	{
 		.name = "AUX H TBT5",
 		.domains = TGL_AUX_H_TBT5_IO_POWER_DOMAINS,
-		.ops = &hsw_power_well_ops,
+		.ops = &icl_tc_phy_aux_power_well_ops,
 		.id = DISP_PW_ID_NONE,
 		{
 			.hsw.regs = &icl_aux_power_well_regs,
@@ -4136,7 +4136,7 @@ static const struct i915_power_well_desc tgl_power_wells[] = {
 	{
 		.name = "AUX I TBT6",
 		.domains = TGL_AUX_I_TBT6_IO_POWER_DOMAINS,
-		.ops = &hsw_power_well_ops,
+		.ops = &icl_tc_phy_aux_power_well_ops,
 		.id = DISP_PW_ID_NONE,
 		{
 			.hsw.regs = &icl_aux_power_well_regs,

--- a/sys/external/bsd/drm2/dist/drm/i915/display/intel_dp.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/display/intel_dp.c
@@ -1,4 +1,5 @@
 /*	$NetBSD: intel_dp.c,v 1.7 2021/12/19 12:41:54 riastradh Exp $	*/
+		.ops = &icl_tc_phy_aux_power_well_ops,
 
 /*
  * Copyright © 2008 Intel Corporation
@@ -2518,9 +2519,6 @@ static void intel_dp_prepare(struct intel_encoder *encoder,
 				 pipe_config->lane_count,
 				 intel_crtc_has_type(pipe_config,
 						     INTEL_OUTPUT_DP_MST));
-
-	intel_dp->regs.dp_tp_ctl = DP_TP_CTL(port);
-	intel_dp->regs.dp_tp_status = DP_TP_STATUS(port);
 
 	/*
 	 * There are four kinds of DP registers:
@@ -7651,6 +7649,8 @@ bool intel_dp_init(struct drm_i915_private *dev_priv,
 
 	intel_dig_port->dp.output_reg = output_reg;
 	intel_dig_port->max_lanes = 4;
+	intel_dig_port->dp.regs.dp_tp_ctl = DP_TP_CTL(port);
+	intel_dig_port->dp.regs.dp_tp_status = DP_TP_STATUS(port);
 
 	intel_encoder->type = INTEL_OUTPUT_DP;
 	intel_encoder->power_domain = intel_port_to_power_domain(port);

--- a/sys/external/bsd/drm2/dist/drm/i915/display/intel_dp.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/display/intel_dp.c
@@ -1,5 +1,4 @@
 /*	$NetBSD: intel_dp.c,v 1.7 2021/12/19 12:41:54 riastradh Exp $	*/
-		.ops = &icl_tc_phy_aux_power_well_ops,
 
 /*
  * Copyright © 2008 Intel Corporation

--- a/sys/external/bsd/drm2/dist/drm/i915/display/intel_fbc.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/display/intel_fbc.c
@@ -485,8 +485,7 @@ static int intel_fbc_alloc_cfb(struct drm_i915_private *dev_priv,
 	if (!ret)
 		goto err_llb;
 	else if (ret > 1) {
-		DRM_INFO("Reducing the compressed framebuffer size. This may lead to less power savings than a non-reduced-size. Try to increase stolen memory size if available in BIOS.\n");
-
+		DRM_INFO_ONCE("Reducing the compressed framebuffer size. This may lead to less power savings than a non-reduced-size. Try to increase stolen memory size if available in BIOS.\n");
 	}
 
 	fbc->threshold = ret;

--- a/sys/external/bsd/drm2/dist/drm/i915/display/intel_sprite.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/display/intel_sprite.c
@@ -2738,19 +2738,25 @@ static bool skl_plane_format_mod_supported(struct drm_plane *_plane,
 	}
 }
 
-static bool gen12_plane_supports_mc_ccs(enum plane_id plane_id)
+static bool gen12_plane_supports_mc_ccs(struct drm_i915_private *dev_priv,
+					enum plane_id plane_id)
 {
+	/* Wa_14010477008:tgl[a0..c0] */
+	if (IS_TGL_REVID(dev_priv, TGL_REVID_A0, TGL_REVID_C0))
+		return false;
+
 	return plane_id < PLANE_SPRITE4;
 }
 
 static bool gen12_plane_format_mod_supported(struct drm_plane *_plane,
 					     u32 format, u64 modifier)
 {
+	struct drm_i915_private *dev_priv = to_i915(_plane->dev);
 	struct intel_plane *plane = to_intel_plane(_plane);
 
 	switch (modifier) {
 	case I915_FORMAT_MOD_Y_TILED_GEN12_MC_CCS:
-		if (!gen12_plane_supports_mc_ccs(plane->id))
+		if (!gen12_plane_supports_mc_ccs(dev_priv, plane->id))
 			return false;
 		/* fall through */
 	case DRM_FORMAT_MOD_LINEAR:
@@ -2919,9 +2925,10 @@ static const u32 *icl_get_plane_formats(struct drm_i915_private *dev_priv,
 	}
 }
 
-static const u64 *gen12_get_plane_modifiers(enum plane_id plane_id)
+static const u64 *gen12_get_plane_modifiers(struct drm_i915_private *dev_priv,
+					    enum plane_id plane_id)
 {
-	if (gen12_plane_supports_mc_ccs(plane_id))
+	if (gen12_plane_supports_mc_ccs(dev_priv, plane_id))
 		return gen12_plane_format_modifiers_mc_ccs;
 	else
 		return gen12_plane_format_modifiers_rc_ccs;
@@ -2992,7 +2999,7 @@ skl_universal_plane_create(struct drm_i915_private *dev_priv,
 
 	plane->has_ccs = skl_plane_has_ccs(dev_priv, pipe, plane_id);
 	if (INTEL_GEN(dev_priv) >= 12) {
-		modifiers = gen12_get_plane_modifiers(plane_id);
+		modifiers = gen12_get_plane_modifiers(dev_priv, plane_id);
 		plane_funcs = &gen12_plane_funcs;
 	} else {
 		if (plane->has_ccs)

--- a/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_domain.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_domain.c
@@ -373,7 +373,6 @@ static void i915_gem_object_bump_inactive_ggtt(struct drm_i915_gem_object *obj)
 	struct drm_i915_private *i915 = to_i915(obj->base.dev);
 	struct i915_vma *vma;
 
-	GEM_BUG_ON(!i915_gem_object_has_pinned_pages(obj));
 	if (!atomic_read(&obj->bind_count))
 		return;
 
@@ -405,12 +404,8 @@ static void i915_gem_object_bump_inactive_ggtt(struct drm_i915_gem_object *obj)
 void
 i915_gem_object_unpin_from_display_plane(struct i915_vma *vma)
 {
-	struct drm_i915_gem_object *obj = vma->obj;
-
-	assert_object_held(obj);
-
 	/* Bump the LRU to try and avoid premature eviction whilst flipping  */
-	i915_gem_object_bump_inactive_ggtt(obj);
+	i915_gem_object_bump_inactive_ggtt(vma->obj);
 
 	i915_vma_unpin(vma);
 }

--- a/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_tiling.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_tiling.c
@@ -190,7 +190,7 @@ i915_gem_object_fence_prepare(struct drm_i915_gem_object *obj,
 {
 	struct i915_ggtt *ggtt = &to_i915(obj->base.dev)->ggtt;
 	struct i915_vma *vma, *vn;
-	LIST_HEAD(unbind);
+	LINUX_LIST_HEAD(unbind);
 	int ret = 0;
 
 	if (tiling_mode == I915_TILING_NONE)

--- a/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_tiling.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_tiling.c
@@ -189,21 +189,35 @@ i915_gem_object_fence_prepare(struct drm_i915_gem_object *obj,
 			      int tiling_mode, unsigned int stride)
 {
 	struct i915_ggtt *ggtt = &to_i915(obj->base.dev)->ggtt;
-	struct i915_vma *vma;
+	struct i915_vma *vma, *vn;
+	LIST_HEAD(unbind);
 	int ret = 0;
 
 	if (tiling_mode == I915_TILING_NONE)
 		return 0;
 
 	mutex_lock(&ggtt->vm.mutex);
+
+	spin_lock(&obj->vma.lock);
 	for_each_ggtt_vma(vma, obj) {
+		GEM_BUG_ON(vma->vm != &ggtt->vm);
+
 		if (i915_vma_fence_prepare(vma, tiling_mode, stride))
 			continue;
 
-		ret = __i915_vma_unbind(vma);
-		if (ret)
-			break;
+		list_move(&vma->vm_link, &unbind);
 	}
+	spin_unlock(&obj->vma.lock);
+
+	list_for_each_entry_safe(vma, vn, &unbind, vm_link) {
+		ret = __i915_vma_unbind(vma);
+		if (ret) {
+			/* Restore the remaining vma on an error */
+			list_splice(&unbind, &ggtt->vm.bound_list);
+			break;
+		}
+	}
+
 	mutex_unlock(&ggtt->vm.mutex);
 
 	return ret;
@@ -275,6 +289,7 @@ i915_gem_object_set_tiling(struct drm_i915_gem_object *obj,
 	}
 	mutex_unlock(&obj->mm.lock);
 
+	spin_lock(&obj->vma.lock);
 	for_each_ggtt_vma(vma, obj) {
 		vma->fence_size =
 			i915_gem_fence_size(i915, vma->size, tiling, stride);
@@ -285,6 +300,7 @@ i915_gem_object_set_tiling(struct drm_i915_gem_object *obj,
 		if (vma->fence)
 			vma->fence->dirty = true;
 	}
+	spin_unlock(&obj->vma.lock);
 
 	obj->tiling_and_stride = tiling | stride;
 	i915_gem_object_unlock(obj);

--- a/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_userptr.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/i915_gem_userptr.c
@@ -649,6 +649,14 @@ static int i915_gem_userptr_get_pages(struct drm_i915_gem_object *obj)
 				      GFP_KERNEL |
 				      __GFP_NORETRY |
 				      __GFP_NOWARN);
+		/*
+		 * Using __get_user_pages_fast() with a read-only
+		 * access is questionable. A read-only page may be
+		 * COW-broken, and then this might end up giving
+		 * the wrong side of the COW..
+		 *
+		 * We may or may not care.
+		 */
 		if (pvec) /* defer to worker if malloc fails */
 			pinned = __get_user_pages_fast(obj->userptr.ptr,
 						       num_pages,

--- a/sys/external/bsd/drm2/dist/drm/i915/gem/selftests/huge_pages.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gem/selftests/huge_pages.c
@@ -1583,8 +1583,10 @@ static int igt_ppgtt_pin_update(void *arg)
 		unsigned int page_size = BIT(first);
 
 		obj = i915_gem_object_create_internal(dev_priv, page_size);
-		if (IS_ERR(obj))
-			return PTR_ERR(obj);
+		if (IS_ERR(obj)) {
+			err = PTR_ERR(obj);
+			goto out_vm;
+		}
 
 		vma = i915_vma_instance(obj, vm, NULL);
 		if (IS_ERR(vma)) {
@@ -1637,8 +1639,10 @@ static int igt_ppgtt_pin_update(void *arg)
 	}
 
 	obj = i915_gem_object_create_internal(dev_priv, PAGE_SIZE);
-	if (IS_ERR(obj))
-		return PTR_ERR(obj);
+	if (IS_ERR(obj)) {
+		err = PTR_ERR(obj);
+		goto out_vm;
+	}
 
 	vma = i915_vma_instance(obj, vm, NULL);
 	if (IS_ERR(vma)) {

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/gen8_ppgtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/gen8_ppgtt.c
@@ -30,6 +30,30 @@ static u64 gen8_pde_encode(const dma_addr_t addr,
 	return pde;
 }
 
+static u64 gen8_pte_encode(dma_addr_t addr,
+			   enum i915_cache_level level,
+			   u32 flags)
+{
+	gen8_pte_t pte = addr | _PAGE_PRESENT | _PAGE_RW;
+
+	if (unlikely(flags & PTE_READ_ONLY))
+		pte &= ~_PAGE_RW;
+
+	switch (level) {
+	case I915_CACHE_NONE:
+		pte |= PPAT_UNCACHED;
+		break;
+	case I915_CACHE_WT:
+		pte |= PPAT_DISPLAY_ELLC;
+		break;
+	default:
+		pte |= PPAT_CACHED;
+		break;
+	}
+
+	return pte;
+}
+
 static void gen8_ppgtt_notify_vgt(struct i915_ppgtt *ppgtt, bool create)
 {
 	struct drm_i915_private *i915 = ppgtt->vm.i915;
@@ -804,6 +828,8 @@ struct i915_ppgtt *gen8_ppgtt_create(struct intel_gt *gt)
 	ppgtt->vm.insert_entries = gen8_ppgtt_insert;
 	ppgtt->vm.allocate_va_range = gen8_ppgtt_alloc;
 	ppgtt->vm.clear_range = gen8_ppgtt_clear;
+
+	ppgtt->vm.pte_encode = gen8_pte_encode;
 
 	if (intel_vgpu_active(gt->i915))
 		gen8_ppgtt_notify_vgt(ppgtt, true);

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine.h
@@ -357,13 +357,4 @@ intel_engine_has_preempt_reset(const struct intel_engine_cs *engine)
 	return intel_engine_has_preemption(engine);
 }
 
-static inline bool
-intel_engine_has_timeslices(const struct intel_engine_cs *engine)
-{
-	if (!IS_ACTIVE(CONFIG_DRM_I915_TIMESLICE_DURATION))
-		return false;
-
-	return intel_engine_has_semaphores(engine);
-}
-
 #endif /* _INTEL_RINGBUFFER_H_ */

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine_cs.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine_cs.c
@@ -305,11 +305,11 @@ static int intel_engine_setup(struct intel_gt *gt, enum intel_engine_id id)
 	engine->id = id;
 	engine->legacy_idx = INVALID_ENGINE;
 	engine->mask = BIT(id);
-	engine->i915 = gt->i915;
+	engine->i915 = i915;
 	engine->gt = gt;
 	engine->uncore = gt->uncore;
 	engine->hw_id = engine->guc_id = info->hw_id;
-	engine->mmio_base = __engine_mmio_base(gt->i915, info->mmio_bases);
+	engine->mmio_base = __engine_mmio_base(i915, info->mmio_bases);
 
 	engine->class = info->class;
 	engine->instance = info->instance;
@@ -324,11 +324,15 @@ static int intel_engine_setup(struct intel_gt *gt, enum intel_engine_id id)
 	engine->props.timeslice_duration_ms =
 		CONFIG_DRM_I915_TIMESLICE_DURATION;
 
+	/* Override to uninterruptible for OpenCL workloads. */
+	if (INTEL_GEN(i915) == 12 && engine->class == RENDER_CLASS)
+		engine->props.preempt_timeout_ms = 0;
+
 	engine->context_size = intel_engine_context_size(gt, engine->class);
 	if (WARN_ON(engine->context_size > BIT(20)))
 		engine->context_size = 0;
 	if (engine->context_size)
-		DRIVER_CAPS(gt->i915)->has_logical_contexts = true;
+		DRIVER_CAPS(i915)->has_logical_contexts = true;
 
 	/* Nothing to do here, execute in order of dependencies */
 	engine->schedule = NULL;
@@ -344,7 +348,7 @@ static int intel_engine_setup(struct intel_gt *gt, enum intel_engine_id id)
 	gt->engine_class[info->class][info->instance] = engine;
 	gt->engine[id] = engine;
 
-	gt->i915->engine[id] = engine;
+	i915->engine[id] = engine;
 
 	return 0;
 }

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine_cs.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine_cs.c
@@ -279,6 +279,7 @@ static void intel_engine_sanitize_mmio(struct intel_engine_cs *engine)
 static int intel_engine_setup(struct intel_gt *gt, enum intel_engine_id id)
 {
 	const struct engine_info *info = &intel_engines[id];
+	struct drm_i915_private *i915 = gt->i915;
 	struct intel_engine_cs *engine;
 
 	BUILD_BUG_ON(MAX_ENGINE_CLASS >= BIT(GEN11_ENGINE_CLASS_WIDTH));

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine_types.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_engine_types.h
@@ -488,10 +488,11 @@ struct intel_engine_cs {
 #define I915_ENGINE_SUPPORTS_STATS   BIT(1)
 #define I915_ENGINE_HAS_PREEMPTION   BIT(2)
 #define I915_ENGINE_HAS_SEMAPHORES   BIT(3)
-#define I915_ENGINE_NEEDS_BREADCRUMB_TASKLET BIT(4)
-#define I915_ENGINE_IS_VIRTUAL       BIT(5)
-#define I915_ENGINE_HAS_RELATIVE_MMIO BIT(6)
-#define I915_ENGINE_REQUIRES_CMD_PARSER BIT(7)
+#define I915_ENGINE_HAS_TIMESLICES   BIT(4)
+#define I915_ENGINE_NEEDS_BREADCRUMB_TASKLET BIT(5)
+#define I915_ENGINE_IS_VIRTUAL       BIT(6)
+#define I915_ENGINE_HAS_RELATIVE_MMIO BIT(7)
+#define I915_ENGINE_REQUIRES_CMD_PARSER BIT(8)
 	unsigned int flags;
 
 	/*
@@ -586,6 +587,15 @@ static inline bool
 intel_engine_has_semaphores(const struct intel_engine_cs *engine)
 {
 	return engine->flags & I915_ENGINE_HAS_SEMAPHORES;
+}
+
+static inline bool
+intel_engine_has_timeslices(const struct intel_engine_cs *engine)
+{
+	if (!IS_ACTIVE(CONFIG_DRM_I915_TIMESLICE_DURATION))
+		return false;
+
+	return engine->flags & I915_ENGINE_HAS_TIMESLICES;
 }
 
 static inline bool

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
@@ -253,12 +253,13 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 	bus_dmamap_t map = vma->pages->sgl[0].sg_dmamap;
 	unsigned seg;
 	unsigned pgno;
+	const gen8_pte_t pte_encode = gen8_pte_encode(0, level, 0);
 #else
 	struct sgt_iter sgt_iter;
 	gen8_pte_t __iomem *gtt_entries;
-#endif
 	gen8_pte_t __iomem *gte;
 	gen8_pte_t __iomem *end;
+#endif
 	dma_addr_t addr;
 
 	/*

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
@@ -254,6 +254,7 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 	bus_dmamap_t map = vma->pages->sgl[0].sg_dmamap;
 	unsigned seg;
 	unsigned pgno;
+	unsigned pgextra;
 #else
 	struct sgt_iter sgt_iter;
 	gen8_pte_t __iomem *gtt_entries;
@@ -269,6 +270,7 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 
 #ifdef __NetBSD__
 	pgno = vma->node.start / I915_GTT_PAGE_SIZE;
+	pgend = pgno + vma->node.size / I915_GTT_PAGE_SIZE;
 	for (seg = 0; seg < map->dm_nsegs; seg++) {
 		addr = map->dm_segs[seg].ds_addr;
 		bus_size_t len = map->dm_segs[seg].ds_len;
@@ -276,9 +278,14 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 		KASSERT((len % I915_GTT_PAGE_SIZE) == 0);
 		for (;
 		     len >= I915_GTT_PAGE_SIZE;
-		     addr += I915_GTT_PAGE_SIZE, len -= I915_GTT_PAGE_SIZE) {
+		     addr += I915_GTT_PAGE_SIZE, len -= I915_GTT_PAGE_SIZE)
 			gen8_set_pte(ggtt->gsmt, ggtt->gsmh, pgno++,
 			    pte_encode | addr);
+		}
+		/* Fill the allocated but "unused" space beyond the end of the buffer */
+		for (;pgno<pgend;pgno++,len--)
+		{
+			gen8_set_pte(ggtt->gsmt + pgno, vm->scratch[0].encode);
 		}
 		KASSERT(len == 0);
 	}

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
@@ -282,12 +282,13 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 			gen8_set_pte(ggtt->gsmt, ggtt->gsmh, pgno++,
 			    pte_encode | addr);
 		}
+		KASSERT(len == 0);
 		/* Fill the allocated but "unused" space beyond the end of the buffer */
-		for (;pgno<pgend;pgno++,len--)
+		KASSERT(pgno <= pgend);
+		for (;pgno<pgend;pgno++)
 		{
 			gen8_set_pte(ggtt->gsmt + pgno, vm->scratch[0].encode);
 		}
-		KASSERT(len == 0);
 	}
 #else
 	gte = (gen8_pte_t __iomem *)ggtt->gsm;

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
@@ -248,12 +248,12 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 				     enum i915_cache_level level,
 				     u32 flags)
 {
+	const gen8_pte_t pte_encode = gen8_ggtt_pte_encode(0, level, 0);
 	struct i915_ggtt *ggtt = i915_vm_to_ggtt(vm);
 #ifdef __NetBSD__
 	bus_dmamap_t map = vma->pages->sgl[0].sg_dmamap;
 	unsigned seg;
 	unsigned pgno;
-	const gen8_pte_t pte_encode = gen8_pte_encode(0, level, 0);
 #else
 	struct sgt_iter sgt_iter;
 	gen8_pte_t __iomem *gtt_entries;
@@ -290,10 +290,11 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 	for_each_sgt_daddr(addr, iter, vma->pages)
 		gen8_set_pte(gte++, pte_encode | addr);
 	GEM_BUG_ON(gte > end);
-#endif
+
 	/* Fill the allocated but "unused" space beyond the end of the buffer */
 	while (gte < end)
 		gen8_set_pte(gte++, vm->scratch[0].encode);
+#endif
 
 	/*
 	 * We want to flush the TLBs only after we're certain all the PTE

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
@@ -254,7 +254,7 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 	bus_dmamap_t map = vma->pages->sgl[0].sg_dmamap;
 	unsigned seg;
 	unsigned pgno;
-	unsigned pgextra;
+	unsigned pgend;
 #else
 	struct sgt_iter sgt_iter;
 	gen8_pte_t __iomem *gtt_entries;
@@ -278,16 +278,16 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 		KASSERT((len % I915_GTT_PAGE_SIZE) == 0);
 		for (;
 		     len >= I915_GTT_PAGE_SIZE;
-		     addr += I915_GTT_PAGE_SIZE, len -= I915_GTT_PAGE_SIZE)
+		     addr += I915_GTT_PAGE_SIZE, len -= I915_GTT_PAGE_SIZE) {
 			gen8_set_pte(ggtt->gsmt, ggtt->gsmh, pgno++,
 			    pte_encode | addr);
 		}
 		KASSERT(len == 0);
 		/* Fill the allocated but "unused" space beyond the end of the buffer */
 		KASSERT(pgno <= pgend);
-		for (;pgno<pgend;pgno++)
+		for (;pgno<pgend;)
 		{
-			gen8_set_pte(ggtt->gsmt + pgno, vm->scratch[0].encode);
+			gen8_set_pte(ggtt->gsmt, ggtt->gsmh, pgno++, vm->scratch[0].encode);
 		}
 	}
 #else

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_ggtt.c
@@ -193,6 +193,13 @@ static void gmch_ggtt_invalidate(struct i915_ggtt *ggtt)
 	intel_gtt_chipset_flush();
 }
 
+static u64 gen8_ggtt_pte_encode(dma_addr_t addr,
+				enum i915_cache_level level,
+				u32 flags)
+{
+	return addr | _PAGE_PRESENT;
+}
+
 #ifdef __NetBSD__
 static inline void
 gen8_set_pte(bus_space_tag_t bst, bus_space_handle_t bsh, unsigned i,
@@ -228,9 +235,9 @@ static void gen8_ggtt_insert_page(struct i915_address_space *vm,
 
 #ifdef __NetBSD__
 	gen8_set_pte(ggtt->gsmt, ggtt->gsmh, offset / I915_GTT_PAGE_SIZE,
-	    gen8_pte_encode(addr, level, 0));
+	    gen8_ggtt_pte_encode(addr, level, 0));
 #else
-	gen8_set_pte(pte, gen8_pte_encode(addr, level, 0));
+	gen8_set_pte(pte, gen8_ggtt_pte_encode(addr, level, 0));
 #endif
 
 	ggtt->invalidate(ggtt);
@@ -250,7 +257,8 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 	struct sgt_iter sgt_iter;
 	gen8_pte_t __iomem *gtt_entries;
 #endif
-	const gen8_pte_t pte_encode = gen8_pte_encode(0, level, 0);
+	gen8_pte_t __iomem *gte;
+	gen8_pte_t __iomem *end;
 	dma_addr_t addr;
 
 	/*
@@ -274,11 +282,17 @@ static void gen8_ggtt_insert_entries(struct i915_address_space *vm,
 		KASSERT(len == 0);
 	}
 #else
-	gtt_entries = (gen8_pte_t __iomem *)ggtt->gsm;
-	gtt_entries += vma->node.start / I915_GTT_PAGE_SIZE;
-	for_each_sgt_daddr(addr, sgt_iter, vma->pages)
-		gen8_set_pte(gtt_entries++, pte_encode | addr);
+	gte = (gen8_pte_t __iomem *)ggtt->gsm;
+	gte += vma->node.start / I915_GTT_PAGE_SIZE;
+	end = gte + vma->node.size / I915_GTT_PAGE_SIZE;
+
+	for_each_sgt_daddr(addr, iter, vma->pages)
+		gen8_set_pte(gte++, pte_encode | addr);
+	GEM_BUG_ON(gte > end);
 #endif
+	/* Fill the allocated but "unused" space beyond the end of the buffer */
+	while (gte < end)
+		gen8_set_pte(gte++, vm->scratch[0].encode);
 
 	/*
 	 * We want to flush the TLBs only after we're certain all the PTE
@@ -329,8 +343,8 @@ static void gen6_ggtt_insert_entries(struct i915_address_space *vm,
 	unsigned seg;
 	unsigned pgno;
 #else
-	gen6_pte_t __iomem *entries = (gen6_pte_t __iomem *)ggtt->gsm;
-	unsigned int i = vma->node.start / I915_GTT_PAGE_SIZE;
+	gen6_pte_t __iomem *gte;
+	gen6_pte_t __iomem *end;
 	struct sgt_iter iter;
 #endif
 	dma_addr_t addr;
@@ -355,8 +369,17 @@ static void gen6_ggtt_insert_entries(struct i915_address_space *vm,
 		/* XXX KASSERT(pgno <= ...)?  */
 	}
 #else
+	gte = (gen6_pte_t __iomem *)ggtt->gsm;
+	gte += vma->node.start / I915_GTT_PAGE_SIZE;
+	end = gte + vma->node.size / I915_GTT_PAGE_SIZE;
+
 	for_each_sgt_daddr(addr, iter, vma->pages)
-		iowrite32(vm->pte_encode(addr, level, flags), &entries[i++]);
+		iowrite32(vm->pte_encode(addr, level, flags), gte++);
+	GEM_BUG_ON(gte > end);
+
+	/* Fill the allocated but "unused" space beyond the end of the buffer */
+	while (gte < end)
+		iowrite32(vm->scratch[0].encode, gte++);
 #endif
 
 	/*
@@ -1064,7 +1087,7 @@ static int gen8_gmch_probe(struct i915_ggtt *ggtt)
 	ggtt->vm.vma_ops.set_pages   = ggtt_set_pages;
 	ggtt->vm.vma_ops.clear_pages = clear_pages;
 
-	ggtt->vm.pte_encode = gen8_pte_encode;
+	ggtt->vm.pte_encode = gen8_ggtt_pte_encode;
 
 	setup_private_pat(ggtt->vm.gt->uncore);
 

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_gtt.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_gtt.c
@@ -575,30 +575,6 @@ void gtt_write_workarounds(struct intel_gt *gt)
 	}
 }
 
-u64 gen8_pte_encode(dma_addr_t addr,
-		    enum i915_cache_level level,
-		    u32 flags)
-{
-	gen8_pte_t pte = addr | _PAGE_PRESENT | _PAGE_RW;
-
-	if (unlikely(flags & PTE_READ_ONLY))
-		pte &= ~_PAGE_RW;
-
-	switch (level) {
-	case I915_CACHE_NONE:
-		pte |= PPAT_UNCACHED;
-		break;
-	case I915_CACHE_WT:
-		pte |= PPAT_DISPLAY_ELLC;
-		break;
-	default:
-		pte |= PPAT_CACHED;
-		break;
-	}
-
-	return pte;
-}
-
 static void tgl_setup_private_ppat(struct intel_uncore *uncore)
 {
 	/* TGL doesn't support LLC or AGE settings */

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_gtt.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_gtt.h
@@ -570,10 +570,6 @@ struct i915_ppgtt *i915_ppgtt_create(struct intel_gt *gt);
 void i915_gem_suspend_gtt_mappings(struct drm_i915_private *i915);
 void i915_gem_restore_gtt_mappings(struct drm_i915_private *i915);
 
-u64 gen8_pte_encode(dma_addr_t addr,
-		    enum i915_cache_level level,
-		    u32 flags);
-
 int setup_page_dma(struct i915_address_space *vm, struct i915_page_dma *p);
 void cleanup_page_dma(struct i915_address_space *vm, struct i915_page_dma *p);
 

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_lrc.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_lrc.c
@@ -1699,6 +1699,9 @@ static void defer_request(struct i915_request *rq, struct list_head * const pl)
 			struct i915_request *w =
 				container_of(p->waiter, typeof(*w), sched);
 
+			if (p->flags & I915_DEPENDENCY_WEAK)
+				continue;
+
 			/* Leave semaphores spinning on the other engines */
 			if (w->engine != rq->engine)
 				continue;
@@ -4286,8 +4289,11 @@ void intel_execlists_set_default_submission(struct intel_engine_cs *engine)
 	engine->flags |= I915_ENGINE_SUPPORTS_STATS;
 	if (!intel_vgpu_active(engine->i915)) {
 		engine->flags |= I915_ENGINE_HAS_SEMAPHORES;
-		if (HAS_LOGICAL_RING_PREEMPTION(engine->i915))
+		if (HAS_LOGICAL_RING_PREEMPTION(engine->i915)) {
 			engine->flags |= I915_ENGINE_HAS_PREEMPTION;
+			if (IS_ACTIVE(CONFIG_DRM_I915_TIMESLICE_DURATION))
+				engine->flags |= I915_ENGINE_HAS_TIMESLICES;
+		}
 	}
 
 	if (INTEL_GEN(engine->i915) >= 12)

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_rps.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_rps.c
@@ -94,7 +94,8 @@ static void rps_enable_interrupts(struct intel_rps *rps)
 	gen6_gt_pm_enable_irq(gt, rps->pm_events);
 	spin_unlock_irq(&gt->irq_lock);
 
-	set(gt->uncore, GEN6_PMINTRMSK, rps_pm_mask(rps, rps->cur_freq));
+	intel_uncore_write(gt->uncore,
+			   GEN6_PMINTRMSK, rps_pm_mask(rps, rps->last_freq));
 }
 
 static void gen6_rps_reset_interrupts(struct intel_rps *rps)
@@ -128,7 +129,8 @@ static void rps_disable_interrupts(struct intel_rps *rps)
 
 	rps->pm_events = 0;
 
-	set(gt->uncore, GEN6_PMINTRMSK, rps_pm_sanitize_mask(rps, ~0u));
+	intel_uncore_write(gt->uncore,
+			   GEN6_PMINTRMSK, rps_pm_sanitize_mask(rps, ~0u));
 
 	spin_lock_irq(&gt->irq_lock);
 	gen6_gt_pm_disable_irq(gt, GEN6_PM_RPS_EVENTS);
@@ -774,6 +776,19 @@ void intel_rps_park(struct intel_rps *rps)
 	intel_uncore_forcewake_get(rps_to_uncore(rps), FORCEWAKE_MEDIA);
 	rps_set(rps, rps->idle_freq, false);
 	intel_uncore_forcewake_put(rps_to_uncore(rps), FORCEWAKE_MEDIA);
+
+	/*
+	 * Since we will try and restart from the previously requested
+	 * frequency on unparking, treat this idle point as a downclock
+	 * interrupt and reduce the frequency for resume. If we park/unpark
+	 * more frequently than the rps worker can run, we will not respond
+	 * to any EI and never see a change in frequency.
+	 *
+	 * (Note we accommodate Cherryview's limitation of only using an
+	 * even bin by applying it to all.)
+	 */
+	rps->cur_freq =
+		max_t(int, round_down(rps->cur_freq - 1, 2), rps->min_freq);
 }
 
 void intel_rps_boost(struct i915_request *rq)

--- a/sys/external/bsd/drm2/dist/drm/i915/gt/intel_timeline.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/gt/intel_timeline.c
@@ -524,6 +524,8 @@ int intel_timeline_read_hwsp(struct i915_request *from,
 
 	rcu_read_lock();
 	cl = rcu_dereference(from->hwsp_cacheline);
+	if (i915_request_completed(from)) /* confirm cacheline is valid */
+		goto unlock;
 	if (unlikely(!i915_active_acquire_if_busy(&cl->active)))
 		goto unlock; /* seqno wrapped and completed! */
 	if (unlikely(i915_request_completed(from)))

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_drv.h
@@ -1640,6 +1640,8 @@ IS_SUBPLATFORM(const struct drm_i915_private *i915,
 	(IS_ICELAKE(p) && IS_REVID(p, since, until))
 
 #define TGL_REVID_A0		0x0
+#define TGL_REVID_B0		0x1
+#define TGL_REVID_C0		0x2
 
 #define IS_TGL_REVID(p, since, until) \
 	(IS_TIGERLAKE(p) && IS_REVID(p, since, until))

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_gem_evict.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_gem_evict.c
@@ -137,6 +137,13 @@ search_again:
 	active = NULL;
 	INIT_LIST_HEAD(&eviction_list);
 	list_for_each_entry_safe(vma, next, &vm->bound_list, vm_link) {
+		if (vma == active) { /* now seen this vma twice */
+			if (flags & PIN_NONBLOCK)
+				break;
+
+			active = ERR_PTR(-EAGAIN);
+		}
+
 		/*
 		 * We keep this list in a rough least-recently scanned order
 		 * of active elements (inactive elements are cheap to reap).
@@ -152,21 +159,12 @@ search_again:
 		 * To notice when we complete one full cycle, we record the
 		 * first active element seen, before moving it to the tail.
 		 */
-		if (i915_vma_is_active(vma)) {
-			if (vma == active) {
-				if (flags & PIN_NONBLOCK)
-					break;
+		if (active != ERR_PTR(-EAGAIN) && i915_vma_is_active(vma)) {
+			if (!active)
+				active = vma;
 
-				active = ERR_PTR(-EAGAIN);
-			}
-
-			if (active != ERR_PTR(-EAGAIN)) {
-				if (!active)
-					active = vma;
-
-				list_move_tail(&vma->vm_link, &vm->bound_list);
-				continue;
-			}
+			list_move_tail(&vma->vm_link, &vm->bound_list);
+			continue;
 		}
 
 		if (mark_free(&scan, vma, flags, &eviction_list))

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_irq.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_irq.c
@@ -3336,7 +3336,8 @@ static void gen8_de_irq_postinstall(struct drm_i915_private *dev_priv)
 {
 	struct intel_uncore *uncore = &dev_priv->uncore;
 
-	u32 de_pipe_masked = GEN8_PIPE_CDCLK_CRC_DONE;
+	u32 de_pipe_masked = gen8_de_pipe_fault_mask(dev_priv) |
+		GEN8_PIPE_CDCLK_CRC_DONE;
 	u32 de_pipe_enables;
 	u32 de_port_masked = GEN8_AUX_CHANNEL_A;
 	u32 de_port_enables;
@@ -3347,13 +3348,10 @@ static void gen8_de_irq_postinstall(struct drm_i915_private *dev_priv)
 		de_misc_masked |= GEN8_DE_MISC_GSE;
 
 	if (INTEL_GEN(dev_priv) >= 9) {
-		de_pipe_masked |= GEN9_DE_PIPE_IRQ_FAULT_ERRORS;
 		de_port_masked |= GEN9_AUX_CHANNEL_B | GEN9_AUX_CHANNEL_C |
 				  GEN9_AUX_CHANNEL_D;
 		if (IS_GEN9_LP(dev_priv))
 			de_port_masked |= BXT_DE_PORT_GMBUS;
-	} else {
-		de_pipe_masked |= GEN8_DE_PIPE_IRQ_FAULT_ERRORS;
 	}
 
 	if (INTEL_GEN(dev_priv) >= 11)

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_irq.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_irq.c
@@ -3339,7 +3339,7 @@ static void gen8_de_irq_postinstall(struct drm_i915_private *dev_priv)
 	u32 de_pipe_masked = gen8_de_pipe_fault_mask(dev_priv) |
 		GEN8_PIPE_CDCLK_CRC_DONE;
 	u32 de_pipe_enables;
-	u32 de_port_masked = GEN8_AUX_CHANNEL_A;
+	u32 de_port_masked = gen8_de_port_aux_mask(dev_priv);
 	u32 de_port_enables;
 	u32 de_misc_masked = GEN8_DE_EDP_PSR;
 	enum pipe pipe;
@@ -3347,18 +3347,8 @@ static void gen8_de_irq_postinstall(struct drm_i915_private *dev_priv)
 	if (INTEL_GEN(dev_priv) <= 10)
 		de_misc_masked |= GEN8_DE_MISC_GSE;
 
-	if (INTEL_GEN(dev_priv) >= 9) {
-		de_port_masked |= GEN9_AUX_CHANNEL_B | GEN9_AUX_CHANNEL_C |
-				  GEN9_AUX_CHANNEL_D;
-		if (IS_GEN9_LP(dev_priv))
-			de_port_masked |= BXT_DE_PORT_GMBUS;
-	}
-
-	if (INTEL_GEN(dev_priv) >= 11)
-		de_port_masked |= ICL_AUX_CHANNEL_E;
-
-	if (IS_CNL_WITH_PORT_F(dev_priv) || INTEL_GEN(dev_priv) >= 11)
-		de_port_masked |= CNL_AUX_CHANNEL_F;
+	if (IS_GEN9_LP(dev_priv))
+		de_port_masked |= BXT_DE_PORT_GMBUS;
 
 	de_pipe_enables = de_pipe_masked | GEN8_PIPE_VBLANK |
 					   GEN8_PIPE_FIFO_UNDERRUN;

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
@@ -3023,21 +3023,11 @@ static int i915_perf_read(struct file *file,
 			  struct uio *buf,
 			  kauth_cred_t count, /* XXX dummy */
 			  int ppos)	      /* XXX dummy */
-#else
-static ssize_t i915_perf_read(struct file *file,
-			      char __user *buf,
-			      size_t count,
-			      loff_t *ppos)
-#endif
 {
-#ifdef __NetBSD__
 	struct i915_perf_stream *stream = file->f_data;
-#else
-	struct i915_perf_stream *stream = file->private_data;
-#endif
 	struct i915_perf *perf = stream->perf;
-	size_t offset2 = 0;
 	int ret;
+	size_t offset_delta = 0;
 
 	/* To ensure it's handled consistently we simply treat all reads of a
 	 * disabled stream as an error. In particular it might otherwise lead
@@ -3046,12 +3036,8 @@ static ssize_t i915_perf_read(struct file *file,
 	if (!stream->enabled)
 		return -EIO;
 
-#ifdef __NetBSD__
 	buf->uio_offset = *offset;
 	if (!(file->f_flag & FNONBLOCK))
-#else
-	if (!(file->f_flags & O_NONBLOCK))
-#endif
 	{
 		/* There's the small chance of false positives from
 		 * stream->ops->wait_unlocked.
@@ -3066,12 +3052,16 @@ static ssize_t i915_perf_read(struct file *file,
 				return ret;
 
 			mutex_lock(&perf->lock);
-			ret = stream->ops->read(stream, buf, count, &offset2);
+			offset_delta=buf->uio_offset;
+			ret = stream->ops->read(stream, buf, count, 0);
+			offset_delta=buf->uio_offset-offset_delta;
 			mutex_unlock(&perf->lock);
-		} while (!offset2 && !ret);
+		} while (!(*offset) && !ret);
 	} else {
 		mutex_lock(&perf->lock);
-		ret = stream->ops->read(stream, buf, count, &offset2);
+		offset_delta=buf->uio_offset;
+		ret = stream->ops->read(stream, buf, count, 0);
+		offset_delta=buf->uio_offset-offset_delta;
 		mutex_unlock(&perf->lock);
 	}
 
@@ -3090,8 +3080,69 @@ static ssize_t i915_perf_read(struct file *file,
 		stream->pollin = false;
 
 	/* Possible values for ret are 0, -EFAULT, -ENOSPC, -EIO, ... */
-	return offset2 ?: (ret ?: -EAGAIN);
+	return (offset_delta) ?: (ret ?: -EAGAIN);
 }
+
+#else
+static ssize_t i915_perf_read(struct file *file,
+			      char __user *buf,
+			      size_t count,
+			      loff_t *ppos)
+{
+	struct i915_perf_stream *stream = file->private_data;
+	struct i915_perf *perf = stream->perf;
+	size_t offset = 0;
+	int ret;
+
+	/* To ensure it's handled consistently we simply treat all reads of a
+	 * disabled stream as an error. In particular it might otherwise lead
+	 * to a deadlock for blocking file descriptors...
+	 */
+	if (!stream->enabled)
+		return -EIO;
+
+	if (!(file->f_flags & O_NONBLOCK))
+	{
+		/* There's the small chance of false positives from
+		 * stream->ops->wait_unlocked.
+		 *
+		 * E.g. with single context filtering since we only wait until
+		 * oabuffer has >= 1 report we don't immediately know whether
+		 * any reports really belong to the current context
+		 */
+		do {
+			ret = stream->ops->wait_unlocked(stream);
+			if (ret)
+				return ret;
+
+			mutex_lock(&perf->lock);
+			ret = stream->ops->read(stream, buf, count, &offset);
+			mutex_unlock(&perf->lock);
+		} while (!offset2 && !ret);
+	} else {
+		mutex_lock(&perf->lock);
+		ret = stream->ops->read(stream, buf, count, &offset);
+		mutex_unlock(&perf->lock);
+	}
+
+	/* We allow the poll checking to sometimes report false positive EPOLLIN
+	 * events where we might actually report EAGAIN on read() if there's
+	 * not really any data available. In this situation though we don't
+	 * want to enter a busy loop between poll() reporting a EPOLLIN event
+	 * and read() returning -EAGAIN. Clearing the oa.pollin state here
+	 * effectively ensures we back off until the next hrtimer callback
+	 * before reporting another EPOLLIN event.
+	 * The exception to this is if ops->read() returned -ENOSPC which means
+	 * that more OA data is available than could fit in the user provided
+	 * buffer. In this case we want the next poll() call to not block.
+	 */
+	if (ret != -ENOSPC)
+		stream->pollin = false;
+
+	/* Possible values for ret are 0, -EFAULT, -ENOSPC, -EIO, ... */
+	return offset ?: (ret ?: -EAGAIN);
+}
+#endif 
 
 static enum hrtimer_restart oa_poll_check_timer_cb(struct hrtimer *hrtimer)
 {

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
@@ -3090,7 +3090,7 @@ static ssize_t i915_perf_read(struct file *file,
 		stream->pollin = false;
 
 	/* Possible values for ret are 0, -EFAULT, -ENOSPC, -EIO, ... */
-	return offset ?: (ret ?: -EAGAIN);
+	return offset2 ?: (ret ?: -EAGAIN);
 }
 
 static enum hrtimer_restart oa_poll_check_timer_cb(struct hrtimer *hrtimer)

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
@@ -3034,9 +3034,10 @@ static ssize_t i915_perf_read(struct file *file,
 	struct i915_perf_stream *stream = file->f_data;
 #else
 	struct i915_perf_stream *stream = file->private_data;
+	size_t offset = 0;
 #endif
 	struct i915_perf *perf = stream->perf;
-	size_t offset = 0;
+	int ret;
 
 	/* To ensure it's handled consistently we simply treat all reads of a
 	 * disabled stream as an error. In particular it might otherwise lead
@@ -3065,12 +3066,20 @@ static ssize_t i915_perf_read(struct file *file,
 				return ret;
 
 			mutex_lock(&perf->lock);
+#ifdef __NetBSD__
+			ret = stream->ops->read(stream, buf, count, offset);
+#else
 			ret = stream->ops->read(stream, buf, count, &offset);
+#endif
 			mutex_unlock(&perf->lock);
 		} while (!offset && !ret);
 	} else {
 		mutex_lock(&perf->lock);
+#ifdef __NetBSD__
+		ret = stream->ops->read(stream, buf, count, offset);
+#else
 		ret = stream->ops->read(stream, buf, count, &offset);
+#endif
 		mutex_unlock(&perf->lock);
 	}
 

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
@@ -3034,9 +3034,9 @@ static ssize_t i915_perf_read(struct file *file,
 	struct i915_perf_stream *stream = file->f_data;
 #else
 	struct i915_perf_stream *stream = file->private_data;
-	size_t offset = 0;
 #endif
 	struct i915_perf *perf = stream->perf;
+	size_t offset2 = 0;
 	int ret;
 
 	/* To ensure it's handled consistently we simply treat all reads of a
@@ -3066,20 +3066,12 @@ static ssize_t i915_perf_read(struct file *file,
 				return ret;
 
 			mutex_lock(&perf->lock);
-#ifdef __NetBSD__
-			ret = stream->ops->read(stream, buf, count, offset);
-#else
-			ret = stream->ops->read(stream, buf, count, &offset);
-#endif
+			ret = stream->ops->read(stream, buf, count, &offset2);
 			mutex_unlock(&perf->lock);
-		} while (!offset && !ret);
+		} while (!offset2 && !ret);
 	} else {
 		mutex_lock(&perf->lock);
-#ifdef __NetBSD__
-		ret = stream->ops->read(stream, buf, count, offset);
-#else
-		ret = stream->ops->read(stream, buf, count, &offset);
-#endif
+		ret = stream->ops->read(stream, buf, count, &offset2);
 		mutex_unlock(&perf->lock);
 	}
 

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
@@ -3118,7 +3118,7 @@ static ssize_t i915_perf_read(struct file *file,
 			mutex_lock(&perf->lock);
 			ret = stream->ops->read(stream, buf, count, &offset);
 			mutex_unlock(&perf->lock);
-		} while (!offset2 && !ret);
+		} while (!offset && !ret);
 	} else {
 		mutex_lock(&perf->lock);
 		ret = stream->ops->read(stream, buf, count, &offset);

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_perf.c
@@ -3000,60 +3000,6 @@ void i915_oa_init_reg_state(const struct intel_context *ce,
 }
 
 /**
- * i915_perf_read_locked - &i915_perf_stream_ops->read with error normalisation
- * @stream: An i915 perf stream
- * @file: An i915 perf stream file
- * @buf: destination buffer given by userspace
- * @count: the number of bytes userspace wants to read
- * @ppos: (inout) file seek position (unused)
- *
- * Besides wrapping &i915_perf_stream_ops->read this provides a common place to
- * ensure that if we've successfully copied any data then reporting that takes
- * precedence over any internal error status, so the data isn't lost.
- *
- * For example ret will be -ENOSPC whenever there is more buffered data than
- * can be copied to userspace, but that's only interesting if we weren't able
- * to copy some data because it implies the userspace buffer is too small to
- * receive a single record (and we never split records).
- *
- * Another case with ret == -EFAULT is more of a grey area since it would seem
- * like bad form for userspace to ask us to overrun its buffer, but the user
- * knows best:
- *
- *   http://yarchive.net/comp/linux/partial_reads_writes.html
- *
- * Returns: The number of bytes copied or a negative error code on failure.
- */
-#ifdef __NetBSD__
-static int i915_perf_read_locked(struct i915_perf_stream *stream,
-				     struct file *file,
-				     struct uio *buf,
-				     kauth_cred_t count, /* XXX dummy */
-				     int ppos)		 /* XXX dummy */
-{
-	return stream->ops->read(stream, buf, count, ppos);
-}
-#else
-static ssize_t i915_perf_read_locked(struct i915_perf_stream *stream,
-				     struct file *file,
-				     char __user *buf,
-				     size_t count,
-				     loff_t *ppos)
-{
-	/* Note we keep the offset (aka bytes read) separate from any
-	 * error status so that the final check for whether we return
-	 * the bytes read with a higher precedence than any error (see
-	 * comment below) doesn't need to be handled/duplicated in
-	 * stream->ops->read() implementations.
-	 */
-	size_t offset = 0;
-	int ret = stream->ops->read(stream, buf, count, &offset);
-
-	return offset ?: (ret ?: -EAGAIN);
-}
-#endif
-
-/**
  * i915_perf_read - handles read() FOP for i915 perf stream FDs
  * @file: An i915 perf stream file
  * @buf: destination buffer given by userspace
@@ -3090,7 +3036,7 @@ static ssize_t i915_perf_read(struct file *file,
 	struct i915_perf_stream *stream = file->private_data;
 #endif
 	struct i915_perf *perf = stream->perf;
-	ssize_t ret;
+	size_t offset = 0;
 
 	/* To ensure it's handled consistently we simply treat all reads of a
 	 * disabled stream as an error. In particular it might otherwise lead
@@ -3119,13 +3065,12 @@ static ssize_t i915_perf_read(struct file *file,
 				return ret;
 
 			mutex_lock(&perf->lock);
-			ret = i915_perf_read_locked(stream, file,
-						    buf, count, ppos);
+			ret = stream->ops->read(stream, buf, count, &offset);
 			mutex_unlock(&perf->lock);
-		} while (ret == -EAGAIN);
+		} while (!offset && !ret);
 	} else {
 		mutex_lock(&perf->lock);
-		ret = i915_perf_read_locked(stream, file, buf, count, ppos);
+		ret = stream->ops->read(stream, buf, count, &offset);
 		mutex_unlock(&perf->lock);
 	}
 
@@ -3136,15 +3081,15 @@ static ssize_t i915_perf_read(struct file *file,
 	 * and read() returning -EAGAIN. Clearing the oa.pollin state here
 	 * effectively ensures we back off until the next hrtimer callback
 	 * before reporting another EPOLLIN event.
+	 * The exception to this is if ops->read() returned -ENOSPC which means
+	 * that more OA data is available than could fit in the user provided
+	 * buffer. In this case we want the next poll() call to not block.
 	 */
-	if (ret >= 0 || ret == -EAGAIN) {
-		/* Maybe make ->pollin per-stream state if we support multiple
-		 * concurrent streams in the future.
-		 */
+	if (ret != -ENOSPC)
 		stream->pollin = false;
-	}
 
-	return ret;
+	/* Possible values for ret are 0, -EFAULT, -ENOSPC, -EIO, ... */
+	return offset ?: (ret ?: -EAGAIN);
 }
 
 static enum hrtimer_restart oa_poll_check_timer_cb(struct hrtimer *hrtimer)

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_request.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_request.c
@@ -941,8 +941,10 @@ i915_request_await_request(struct i915_request *to, struct i915_request *from)
 	GEM_BUG_ON(to == from);
 	GEM_BUG_ON(to->timeline == from->timeline);
 
-	if (i915_request_completed(from))
+	if (i915_request_completed(from)) {
+		i915_sw_fence_set_error_once(&to->submit, from->fence.error);
 		return 0;
+	}
 
 	if (to->engine->schedule) {
 		ret = i915_sched_node_add_dependency(&to->sched,

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_request.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_request.c
@@ -945,7 +945,9 @@ i915_request_await_request(struct i915_request *to, struct i915_request *from)
 		return 0;
 
 	if (to->engine->schedule) {
-		ret = i915_sched_node_add_dependency(&to->sched, &from->sched);
+		ret = i915_sched_node_add_dependency(&to->sched,
+						     &from->sched,
+						     I915_DEPENDENCY_EXTERNAL);
 		if (ret < 0)
 			return ret;
 	}
@@ -1078,7 +1080,9 @@ __i915_request_await_execution(struct i915_request *to,
 
 	/* Couple the dependency tree for PI on this exposed to->fence */
 	if (to->engine->schedule) {
-		err = i915_sched_node_add_dependency(&to->sched, &from->sched);
+		err = i915_sched_node_add_dependency(&to->sched,
+						     &from->sched,
+						     I915_DEPENDENCY_WEAK);
 		if (err < 0)
 			return err;
 	}

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_scheduler.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_scheduler.c
@@ -534,7 +534,8 @@ bool __i915_sched_node_add_dependency(struct i915_sched_node *node,
 }
 
 int i915_sched_node_add_dependency(struct i915_sched_node *node,
-				   struct i915_sched_node *signal)
+				   struct i915_sched_node *signal,
+				   unsigned long flags)
 {
 	struct i915_dependency *dep;
 
@@ -543,8 +544,7 @@ int i915_sched_node_add_dependency(struct i915_sched_node *node,
 		return -ENOMEM;
 
 	if (!__i915_sched_node_add_dependency(node, signal, dep,
-					      I915_DEPENDENCY_EXTERNAL |
-					      I915_DEPENDENCY_ALLOC))
+					      flags | I915_DEPENDENCY_ALLOC))
 		i915_dependency_free(dep);
 
 	return 0;

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_scheduler.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_scheduler.h
@@ -36,7 +36,8 @@ bool __i915_sched_node_add_dependency(struct i915_sched_node *node,
 				      unsigned long flags);
 
 int i915_sched_node_add_dependency(struct i915_sched_node *node,
-				   struct i915_sched_node *signal);
+				   struct i915_sched_node *signal,
+				   unsigned long flags);
 
 void i915_sched_node_fini(struct i915_sched_node *node);
 

--- a/sys/external/bsd/drm2/dist/drm/i915/i915_scheduler_types.h
+++ b/sys/external/bsd/drm2/dist/drm/i915/i915_scheduler_types.h
@@ -80,6 +80,7 @@ struct i915_dependency {
 	unsigned long flags;
 #define I915_DEPENDENCY_ALLOC		BIT(0)
 #define I915_DEPENDENCY_EXTERNAL	BIT(1)
+#define I915_DEPENDENCY_WEAK		BIT(2)
 };
 
 #endif /* _I915_SCHEDULER_TYPES_H_ */

--- a/sys/external/bsd/drm2/dist/drm/i915/intel_pm.c
+++ b/sys/external/bsd/drm2/dist/drm/i915/intel_pm.c
@@ -4731,7 +4731,7 @@ static void skl_compute_plane_wm(const struct intel_crtc_state *crtc_state,
 	 * WaIncreaseLatencyIPCEnabled: kbl,cfl
 	 * Display WA #1141: kbl,cfl
 	 */
-	if ((IS_KABYLAKE(dev_priv) || IS_COFFEELAKE(dev_priv)) ||
+	if ((IS_KABYLAKE(dev_priv) || IS_COFFEELAKE(dev_priv)) &&
 	    dev_priv->ipc_enabled)
 		latency += 4;
 


### PR DESCRIPTION
Hello!


This is my first attempt at a pull request to the NetBSD kernel. I need A LOT of review for this one....
Since I wanted to make my Intel Graphics work, I took the liberty of closing the gap between the i915 driver inside the NetBSD and Linux Kernel a little bit.

This one is bringing the current code (apparently from 5.6.4) to Linux 5.6.19.
(*) MY BIGGEST APOLOGY: Thus far, I only compiled it. I did not run it: The only computer with an integrated Intel Graphics is still too new, so.... Somebody else has to check it. 


TODOS (not me):

- [ ] compile it
- [ ] RUN IT on an actual machine (* see above, sorry about this one)
- [ ] Double check the Kernel API calls
- [ ] Verify the coding style
- [ ] Verify the licenses of the merged files


