### PR TITLE
Add missing POSIX sig2str(3) & str2sig(3) calls

### DIFF
--- a/distrib/sets/lists/tests/mi
+++ b/distrib/sets/lists/tests/mi
@@ -1,4 +1,4 @@
-# $NetBSD: mi,v 1.1380 2025/06/13 03:51:17 rillig Exp $
+# $NetBSD$
 #
 # Note: don't delete entries from here - mark them as "obsolete" instead.
 #
@@ -3231,6 +3231,10 @@
 ./usr/tests/lib/libc/setjmp/t_setjmp			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/setjmp/t_sigstack			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/setjmp/t_threadjmp			tests-lib-tests		compattestfile,atf
+./usr/tests/lib/libc/signal				tests-lib-tests		compattestfile,atf
+./usr/tests/lib/libc/signal/Atffile			tests-lib-tests		compattestfile,atf
+./usr/tests/lib/libc/signal/Kyuafile			tests-lib-tests		compattestfile,atf,kyua
+./usr/tests/lib/libc/signal/t_sig2str			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/ssp				tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/ssp/Atffile			tests-lib-tests		compattestfile,atf,ssp
 ./usr/tests/lib/libc/ssp/Kyuafile			tests-lib-tests		compattestfile,atf,ssp,kyua

--- a/etc/mtree/NetBSD.dist.tests
+++ b/etc/mtree/NetBSD.dist.tests
@@ -1,4 +1,4 @@
-#	$NetBSD: NetBSD.dist.tests,v 1.210 2025/01/18 22:31:22 rillig Exp $
+#	$NetBSD$
 
 ./usr/libdata/debug/usr/tests
 ./usr/libdata/debug/usr/tests/atf
@@ -310,6 +310,7 @@
 ./usr/tests/lib/libc/regex/data
 ./usr/tests/lib/libc/rpc
 ./usr/tests/lib/libc/setjmp
+./usr/tests/lib/libc/signal
 ./usr/tests/lib/libc/ssp
 ./usr/tests/lib/libc/stdio
 ./usr/tests/lib/libc/stdlib

--- a/external/bsd/libproc/dist/libproc.h
+++ b/external/bsd/libproc/dist/libproc.h
@@ -106,8 +106,6 @@ typedef enum {
 	REG_RVAL2
 } proc_reg_t;
 
-#define SIG2STR_MAX	8
-
 typedef struct lwpstatus {
 	int pr_why;
 #define PR_REQUESTED	1

--- a/include/signal.h
+++ b/include/signal.h
@@ -1,4 +1,4 @@
-/*	$NetBSD: signal.h,v 1.60 2024/09/09 21:19:54 rillig Exp $	*/
+/*	$NetBSD$	*/
 
 /*-
  * Copyright (c) 1991, 1993
@@ -203,6 +203,11 @@ int	__sigtimedwait(const sigset_t * __restrict,
 #endif
 #endif /* _POSIX_C_SOURCE >= 199309L || _XOPEN_SOURCE_EXTENDED || ... */
 
+#if (_POSIX_C_SOURCE - 0) >= 202405L || defined(_NETBSD_SOURCE)
+#define SIG2STR_MAX	32	/* size of buffer required for sig2str() */
+int sig2str(int, char *);
+int str2sig(const char * __restrict, int * __restrict);
+#endif
 
 #if defined(_NETBSD_SOURCE)
 #ifndef __PSIGNAL_DECLARED

--- a/lib/libc/gen/Makefile.inc
+++ b/lib/libc/gen/Makefile.inc
@@ -1,4 +1,4 @@
-#	$NetBSD: Makefile.inc,v 1.225 2025/04/22 09:41:17 nia Exp $
+#	$NetBSD$
 #	from: @(#)Makefile.inc	8.6 (Berkeley) 5/4/95
 
 # gen sources
@@ -28,7 +28,7 @@ SRCS+=	alarm.c alphasort.c arc4random.c assert.c asysctl.c \
 	ptree.c pwcache.c pw_scan.c raise.c randomid.c rb.c readdir.c \
 	rewinddir.c scandir.c seekdir.c setdomainname.c \
 	sethostname.c setjmperr.c setmode.c setproctitle.c setprogname.c \
-	shquote.c shquotev.c sighold.c sigignore.c siginterrupt.c \
+	shquote.c shquotev.c sig2str.c sighold.c sigignore.c siginterrupt.c \
 	siglist.c signal.c signalname.c signalnext.c signalnumber.c \
 	signame.c sigrelse.c sigset.c sigsetops.c sleep.c \
 	stringlist.c sysconf.c sysctl.c sysctlbyname.c sysctlgetmibinfo.c \
@@ -171,7 +171,8 @@ MLINKS+=posix_spawn.3 posix_spawnp.3 \
 	posix_spawnattr_getsigdefault.3 posix_spawnattr_setsigdefault.3 \
 	posix_spawnattr_getsigmask.3 posix_spawnattr_setsigmask.3 \
 	posix_spawnattr_init.3 posix_spawnattr_destroy.3
-MLINKS+=psignal.3 sys_siglist.3 psignal.3 sys_signame.3 psignal.3 psiginfo.3
+MLINKS+=psignal.3 sys_siglist.3 psignal.3 sys_signame.3 psignal.3 psiginfo.3 \
+	psignal.3 sig2str.3 psignal.3 str2sig.3
 MLINKS+=pwcache.3 user_from_uid.3 pwcache.3 group_from_gid.3
 MLINKS+=pwcache.3 uid_from_user.3 pwcache.3 gid_from_group.3
 MLINKS+=pwcache.3 pwcache_userdb.3 pwcache.3 pwcache_groupdb.3

--- a/lib/libc/gen/psignal.3
+++ b/lib/libc/gen/psignal.3
@@ -1,4 +1,4 @@
-.\"	$NetBSD: psignal.3,v 1.17 2010/08/27 08:38:41 christos Exp $
+.\"	$NetBSD$
 .\"
 .\" Copyright (c) 1983, 1991, 1993
 .\"	The Regents of the University of California.  All rights reserved.
@@ -29,12 +29,14 @@
 .\"
 .\"     @(#)psignal.3	8.2 (Berkeley) 2/27/95
 .\"
-.Dd August 27, 2010
+.Dd June 15, 2025
 .Dt PSIGNAL 3
 .Os
 .Sh NAME
 .Nm psignal ,
 .Nm psiginfo ,
+.Nm sig2str ,
+.Nm str2sig ,
 .Nm sys_siglist ,
 .Nm sys_signame
 .Nd system signal messages
@@ -45,6 +47,10 @@
 .Ft void
 .Fn psignal "int sig" "const char *s"
 .Fn psiginfo "const siginfo_t *si" "const char *s"
+.Ft int
+.Fn sig2str "int signum" "char *str"
+.Ft int
+.Fn str2sig "char *str" "int *pnum"
 .Vt extern const char * const sys_siglist[];
 .Vt extern const char * const sys_signame[];
 .Sh DESCRIPTION
@@ -89,11 +95,51 @@ contains a count of the strings in
 .Va sys_siglist
 and
 .Va sys_signame .
+.Pp
+The
+.Fn sig2str
+function translates the signal number
+.Fa signum
+to the signal name, without the
+.Dq SIG
+prefix, and stores it at the location specified by
+.Fa str ,
+which should be large enough to hold the name and the terminating
+.Dv NUL
+byte.
+The symbol
+.Dv SIG2STR_MAX
+gives the maximum size in bytes required.
+.Pp
+The
+.Fn str2sig
+function translates the signal name
+.Fa str
+to a signal number and stores it in the location referenced by
+.Fa pnum .
+The name in
+.Fa str
+can be either the name of the signal, with or without the
+.Dq SIG
+prefix, or a decimal number.
 .Sh SEE ALSO
 .Xr sigaction 2 ,
 .Xr perror 3 ,
 .Xr setlocale 3 ,
 .Xr strsignal 3
+.Sh STANDARDS
+The
+.Fn psignal
+and
+.Fn psiginfo
+functions are defined by
+.St -p1003.1-2008
+, while the
+.Fn sig2str
+and
+.Fn str2sig
+functions are defined by
+.St -p1003.1-2024 .
 .Sh HISTORY
 The
 .Fn psignal
@@ -103,3 +149,11 @@ The
 .Fn psiginfo
 function appeared in
 .Nx 6.0 .
+The
+.Fn sig2str
+and
+.Fn str2sig
+functions appeared in
+.Fx 15.0
+and
+.Nx 11.0 .

--- a/lib/libc/gen/sig2str.c
+++ b/lib/libc/gen/sig2str.c
@@ -1,0 +1,119 @@
+/* $NetBSD$ */
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Ricardo Branco <rbranco@suse.de>.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Translate between signal names and numbers
+ */
+
+#include <sys/cdefs.h>
+#if defined(LIBC_SCCS) && !defined(lint)
+__RCSID("$NetBSD$");
+#endif /* LIBC_SCCS and not lint */
+
+#include "namespace.h"
+
+#include <ctype.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+
+static const char rtmin_str[] = "RTMIN";
+static const char rtmax_str[] = "RTMAX";
+
+int
+sig2str(int signum, char *str)
+{
+	if (signum <= 0 || signum > SIGRTMAX)
+		return (-1);
+
+	if (signum < sys_nsig)
+		(void)strlcpy(str, sys_signame[signum], SIG2STR_MAX);
+	else if (signum < SIGRTMIN)
+		(void)snprintf(str, SIG2STR_MAX, "%d", signum);
+	else if (signum == SIGRTMIN)
+		(void)strlcpy(str, rtmin_str, SIG2STR_MAX);
+	else if (signum == SIGRTMAX)
+		(void)strlcpy(str, rtmax_str, SIG2STR_MAX);
+	else if (signum <= (SIGRTMIN + SIGRTMAX) / 2)
+		(void)snprintf(str, SIG2STR_MAX, "%s+%d",
+		    rtmin_str, signum - SIGRTMIN);
+	else
+		(void)snprintf(str, SIG2STR_MAX, "%s-%d",
+		    rtmax_str, SIGRTMAX - signum);
+
+	return (0);
+}
+
+int
+str2sig(const char * restrict str, int * restrict pnum)
+{
+	intmax_t n;
+	int e, sig;
+
+	if (strncasecmp(str, "SIG", 3) == 0)
+		str += 3;
+
+	if (strncasecmp(str, rtmin_str, sizeof(rtmin_str) - 1) == 0 ||
+	    strncasecmp(str, rtmax_str, sizeof(rtmax_str) - 1) == 0) {
+		sig = (toupper((unsigned char)str[4]) == 'X') ?
+		    SIGRTMAX : SIGRTMIN;
+		n = 0;
+		if (str[5] == '+' || str[5] == '-') {
+			n = strtoi(str + 5, NULL, 10, INT_MIN, INT_MAX, &e);
+			if (n == 0 || e != 0)
+				return (-1);
+		} else if (str[5] != '\0') {
+			return (-1);
+		}
+		sig += (int)n;
+		if (sig < SIGRTMIN || sig > SIGRTMAX)
+			return (-1);
+		*pnum = sig;
+		return (0);
+	}
+
+	if (isdigit((unsigned char)str[0])) {
+		n = strtoi(str, NULL, 10, 1, SIGRTMAX, &e);
+		if (e == 0) {
+			*pnum = (int)n;
+			return (0);
+		}
+	}
+
+	for (sig = 1; sig < sys_nsig; sig++) {
+		if (strcasecmp(sys_signame[sig], str) == 0) {
+			*pnum = sig;
+			return (0);
+		}
+	}
+
+	return (-1);
+}

--- a/tests/lib/libc/Makefile
+++ b/tests/lib/libc/Makefile
@@ -1,4 +1,4 @@
-# $NetBSD: Makefile,v 1.52 2022/04/29 22:17:49 pgoyette Exp $
+# $NetBSD$
 
 .include "Makefile.inc"
 .include <bsd.own.mk>
@@ -20,6 +20,7 @@ TESTS_SUBDIRS+=	nls
 TESTS_SUBDIRS+=	regex
 TESTS_SUBDIRS+=	rpc
 TESTS_SUBDIRS+=	setjmp
+TESTS_SUBDIRS+=	signal
 TESTS_SUBDIRS+=	stdio
 TESTS_SUBDIRS+=	stdlib
 TESTS_SUBDIRS+=	string

--- a/tests/lib/libc/signal/Makefile
+++ b/tests/lib/libc/signal/Makefile
@@ -1,0 +1,11 @@
+# $NetBSD$
+
+.include <bsd.own.mk>
+
+TESTSDIR=	${TESTSBASE}/lib/libc/signal
+
+TESTS_C+=	t_sig2str
+
+WARNS=		4
+
+.include <bsd.test.mk>

--- a/tests/lib/libc/signal/t_sig2str.c
+++ b/tests/lib/libc/signal/t_sig2str.c
@@ -1,0 +1,215 @@
+/* $NetBSD$ */
+
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2025 Ricardo Branco <rbranco@suse.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <atf-c.h>
+
+static void
+test_roundtrip(int signum)
+{
+	char str[SIG2STR_MAX];
+	int sig;
+
+	ATF_REQUIRE_EQ_MSG(sig2str(signum, str), 0,
+	    "sig2str(%d) failed", signum);
+	ATF_REQUIRE_EQ_MSG(str2sig(str, &sig), 0,
+	    "str2sig(\"%s\") failed", str);
+	ATF_REQUIRE_EQ_MSG(sig, signum,
+	    "Mismatch: roundtrip conversion gave %d instead of %d",
+	    sig, signum);
+}
+
+ATF_TC_WITHOUT_HEAD(sig2str_valid);
+ATF_TC_BODY(sig2str_valid, tc)
+{
+	int sig;
+
+	for (sig = 1; sig < sys_nsig; sig++) {
+		test_roundtrip(sig);
+	}
+}
+
+ATF_TC_WITHOUT_HEAD(sig2str_invalid);
+ATF_TC_BODY(sig2str_invalid, tc)
+{
+	char buf[SIG2STR_MAX];
+
+	ATF_CHECK(sig2str(0, buf) != 0);
+	ATF_CHECK(sig2str(-1, buf) != 0);
+	ATF_CHECK(sig2str(SIGRTMAX + 1, buf) != 0);
+}
+
+ATF_TC_WITHOUT_HEAD(str2sig_rtmin_rtmax);
+ATF_TC_BODY(str2sig_rtmin_rtmax, tc)
+{
+	int sig;
+
+	ATF_CHECK_MSG(str2sig("RTMIN", &sig) == 0,
+	    "str2sig(\"RTMIN\") failed");
+	ATF_CHECK_EQ_MSG(sig, SIGRTMIN,
+	    "RTMIN mapped to %d, expected %d", sig, SIGRTMIN);
+
+	ATF_CHECK_MSG(str2sig("RTMAX", &sig) == 0,
+	    "str2sig(\"RTMAX\") failed");
+	ATF_CHECK_EQ_MSG(sig, SIGRTMAX,
+	    "RTMAX mapped to %d, expected %d", sig, SIGRTMAX);
+
+	ATF_CHECK_MSG(str2sig("RTMIN+1", &sig) == 0,
+	    "str2sig(\"RTMIN+1\") failed");
+	ATF_CHECK_EQ_MSG(sig, SIGRTMIN + 1,
+	    "RTMIN+1 mapped to %d, expected %d", sig, SIGRTMIN + 1);
+
+	ATF_CHECK_MSG(str2sig("RTMAX-1", &sig) == 0,
+	    "str2sig(\"RTMAX-1\") failed");
+	ATF_CHECK_EQ_MSG(sig, SIGRTMAX - 1,
+	    "RTMAX-1 mapped to %d, expected %d", sig, SIGRTMAX - 1);
+}
+
+ATF_TC_WITHOUT_HEAD(str2sig_invalid_rt);
+ATF_TC_BODY(str2sig_invalid_rt, tc)
+{
+	int i, sig;
+
+	const char *invalid[] = {
+		"RTMIN+0",
+		"RTMAX-0",
+		"RTMIN-777",
+		"RTMIN+777",
+		"RTMAX-777",
+		"RTMAX+777",
+		"RTMIN-",
+		"RTMAX-",
+		"RTMIN0",
+		"RTMAX1",
+		"RTMIN+abc",
+		"RTMIN-abc",
+		NULL
+	};
+
+	for (i = 0; invalid[i] != NULL; i++) {
+		ATF_CHECK_MSG(str2sig(invalid[i], &sig) != 0,
+		    "str2sig(\"%s\") unexpectedly succeeded", invalid[i]);
+	}
+}
+
+ATF_TC_WITHOUT_HEAD(str2sig_fullname);
+ATF_TC_BODY(str2sig_fullname, tc)
+{
+	char fullname[SIG2STR_MAX + 3];
+	int n, sig;
+
+	for (sig = 1; sig < sys_nsig; sig++) {
+		snprintf(fullname, sizeof(fullname), "SIG%s", sys_signame[sig]);
+
+		ATF_CHECK_MSG(str2sig(fullname, &n) == 0,
+		    "str2sig(\"%s\") failed with errno %d (%s)",
+		    fullname, errno, strerror(errno));
+
+		ATF_CHECK_EQ_MSG(n, sig,
+		    "Mismatch: %s = %d, str2sig(\"%s\") = %d",
+		    sys_signame[sig], sig, fullname, n);
+	}
+}
+
+ATF_TC_WITHOUT_HEAD(str2sig_lowercase);
+ATF_TC_BODY(str2sig_lowercase, tc)
+{
+	char fullname[SIG2STR_MAX + 3];
+	int n, sig;
+
+	for (sig = 1; sig < sys_nsig; sig++) {
+		snprintf(fullname, sizeof(fullname), "sig%s", sys_signame[sig]);
+		for (size_t i = 3; i < strlen(fullname); i++)
+			fullname[i] = toupper((unsigned char)fullname[i]);
+
+		ATF_CHECK_MSG(str2sig(fullname, &n) == 0,
+		    "str2sig(\"%s\") failed with errno %d (%s)",
+		    fullname, errno, strerror(errno));
+
+		ATF_CHECK_EQ_MSG(n, sig,
+		    "Mismatch: %s = %d, str2sig(\"%s\") = %d",
+		    sys_signame[sig], sig, fullname, n);
+	}
+}
+
+ATF_TC_WITHOUT_HEAD(str2sig_numeric);
+ATF_TC_BODY(str2sig_numeric, tc)
+{
+	char buf[16];
+	int n, sig;
+
+	for (sig = NSIG; sig < SIGRTMIN; sig++) {
+		snprintf(buf, sizeof(buf), "%d", sig);
+		ATF_CHECK_MSG(str2sig(buf, &n) == 0,
+		    "str2sig(\"%s\") failed", buf);
+		ATF_CHECK_EQ_MSG(n, sig,
+		    "Mismatch: str2sig(\"%s\") = %d, expected %d",
+		    buf, n, sig);
+	}
+}
+
+ATF_TC_WITHOUT_HEAD(str2sig_invalid);
+ATF_TC_BODY(str2sig_invalid, tc)
+{
+	const char *invalid[] = {
+		"SIGDOESNOTEXIST",
+		"DOESNOTEXIST",
+		"INTERRUPT",
+		"",
+		"SIG",
+		"123abc",
+		"sig1extra",
+		NULL
+	};
+	int i, sig;
+
+	for (i = 0; invalid[i] != NULL; i++) {
+		ATF_CHECK_MSG(str2sig(invalid[i], &sig) != 0,
+		    "str2sig(\"%s\") unexpectedly succeeded", invalid[i]);
+	}
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+	ATF_TP_ADD_TC(tp, sig2str_valid);
+	ATF_TP_ADD_TC(tp, sig2str_invalid);
+	ATF_TP_ADD_TC(tp, str2sig_rtmin_rtmax);
+	ATF_TP_ADD_TC(tp, str2sig_invalid_rt);
+	ATF_TP_ADD_TC(tp, str2sig_fullname);
+	ATF_TP_ADD_TC(tp, str2sig_lowercase);
+	ATF_TP_ADD_TC(tp, str2sig_numeric);
+	ATF_TP_ADD_TC(tp, str2sig_invalid);
+	return (atf_no_error());
+}


### PR DESCRIPTION
Recently added to FreeBSD: https://github.com/freebsd/freebsd-src/pull/1696

Add `sig2str(3)` & `str2sig(3)` calls defined in POSIX 1003.1-2024:
- https://pubs.opengroup.org/onlinepubs/9799919799/functions/sig2str.html

Also add needed `SIG2STR_MAX` definition:
- https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/signal.h.html

Fixes [lib/59467](https://gnats.netbsd.org/59467)