### PR TITLE
Fix arm64 32bit pcc for cpu-freq scaling

### DIFF
--- a/sys/dev/acpi/acpi_pcc.c
+++ b/sys/dev/acpi/acpi_pcc.c
@@ -265,7 +265,6 @@ pcc_send_command(struct pcc_subspace *ss, ACPI_GENERIC_ADDRESS *reg,
 {
 	volatile ACPI_PCCT_SHARED_MEMORY *shmem = ss->ss_data;
 	uint8_t *data = __UNVOLATILE(shmem + 1);
-	UINT64 tmp, mask;
 
 	KASSERT(ss->ss_type == ACPI_PCCT_TYPE_GENERIC_SUBSPACE ||
 	        ss->ss_type == ACPI_PCCT_TYPE_HW_REDUCED_SUBSPACE ||
@@ -274,12 +273,27 @@ pcc_send_command(struct pcc_subspace *ss, ACPI_GENERIC_ADDRESS *reg,
 	shmem->Signature = PCC_SIGNATURE(ss->ss_id);
 	shmem->Command = command & 0xff;
 	if ((flags & PCC_WRITE) != 0) {
-		mask = __BITS(reg->BitOffset + reg->BitWidth - 1,
-			      reg->BitOffset);
-		ACPI_MOVE_64_TO_64(&tmp, data + reg->Address);
-		tmp &= mask;
-		tmp |= __SHIFTIN(val, mask);
-		ACPI_MOVE_64_TO_64(data + reg->Address, &tmp);
+		if (reg->BitWidth == 32U) {
+			UINT32 tmp32, mask32, val32;
+			val32 = (UINT32)val;
+			mask32 = __BITS(reg->BitOffset + reg->BitWidth - 1,
+					reg->BitOffset);
+			ACPI_MOVE_32_TO_32(&tmp32, data + reg->Address);
+			tmp32 &= ~mask32;
+			tmp32 |= __SHIFTIN(val32, mask32);
+			aprint_normal("%s PCC32 write %d %ld mask 0x%x\n", __func__, tmp32, val, mask32);
+			ACPI_MOVE_32_TO_32(data + reg->Address, &tmp32);
+		} else if (reg->BitWidth == 64U) {
+			UINT64 tmp, mask;
+			mask = __BITS(reg->BitOffset + reg->BitWidth - 1,
+					reg->BitOffset);
+			ACPI_MOVE_64_TO_64(&tmp, data + reg->Address);
+			tmp &= ~mask;
+			tmp |= __SHIFTIN(val, mask);
+			ACPI_MOVE_64_TO_64(data + reg->Address, &tmp);
+		} else {
+			panic("PCC %d bit not support\n", reg->BitWidth);
+		}
 	}
 	PCC_MEMORY_BARRIER();
 	shmem->Status &= ~(PCC_STATUS_COMMAND_COMPLETE |
@@ -300,7 +314,6 @@ pcc_receive_response(struct pcc_subspace *ss, ACPI_GENERIC_ADDRESS *reg,
 {
 	volatile ACPI_PCCT_SHARED_MEMORY *shmem = ss->ss_data;
 	const uint8_t *data = __UNVOLATILE(shmem + 1);
-	UINT64 tmp, mask;
 
 	KASSERT(ss->ss_type == ACPI_PCCT_TYPE_GENERIC_SUBSPACE ||
 	        ss->ss_type == ACPI_PCCT_TYPE_HW_REDUCED_SUBSPACE ||
@@ -313,10 +326,23 @@ pcc_receive_response(struct pcc_subspace *ss, ACPI_GENERIC_ADDRESS *reg,
 	}
 
 	if ((flags & PCC_READ) != 0) {
-		mask = __BITS(reg->BitOffset + reg->BitWidth - 1,
-			      reg->BitOffset);
-		ACPI_MOVE_64_TO_64(&tmp, data + reg->Address);
-		*val = __SHIFTOUT(tmp, mask);
+		if (reg->BitWidth == 32U) {
+			UINT32 tmp32, mask32, val32;
+			mask32 = __BITS(reg->BitOffset + reg->BitWidth - 1,
+					reg->BitOffset);
+			ACPI_MOVE_32_TO_32(&tmp32, data + reg->Address);
+			val32 = __SHIFTOUT(tmp32, mask32);
+			*val = (UINT64)val32;
+			aprint_normal("%s PCC32 read %d %ld mask 0x%x\n", __func__, tmp32, *val, mask32);
+		} else if (reg->BitWidth == 64U) {
+			UINT64 tmp, mask;
+			mask = __BITS(reg->BitOffset + reg->BitWidth - 1,
+					reg->BitOffset);
+			ACPI_MOVE_64_TO_64(&tmp, data + reg->Address);
+			*val = __SHIFTOUT(tmp, mask);
+		} else {
+			panic("PCC %d bit not support\n", reg->BitWidth);
+		}
 	}
 
 	return AE_OK;


### PR DESCRIPTION
This PR is to fix cpu frequency scaling in some arm64 platform

1): the current acpi_pcc.c do not handle for **reg->BitWidth = 32** case，therefore some arm64 platform failed with Data aligment abort when init cppc
2): the current acpi_pcc.c mis-use mask when write new cpu freq into pcc channel

```c
static ACPI_STATUS
pcc_send_command(struct pcc_subspace *ss, ACPI_GENERIC_ADDRESS *reg,
    uint32_t command, int flags, ACPI_INTEGER val)
{
  ...
	if ((flags & PCC_WRITE) != 0) {
		mask = __BITS(reg->BitOffset + reg->BitWidth - 1,
			      reg->BitOffset);
		ACPI_MOVE_64_TO_64(&tmp, data + reg->Address);
		tmp &= mask; // shall be 'tmp &= ~mask;' here
		tmp |= __SHIFTIN(val, mask);
		ACPI_MOVE_64_TO_64(data + reg->Address, &tmp);
	}
}
```

- I verify the code in my ARM64 pc with ubench before and after cpu-freq scale
- My build is
```
./build.sh -U -u -j12 -O /usr/obj.aarch64 -m evbarm -a aarch64 release
```

- My test platform is
```
arm64# uname -a
NetBSD arm64 10.1_STABLE NetBSD 10.1_STABLE (GENERIC64) #14: Tue Jul  8 06:26:17 CST 2025
```

- cpu-freq scale

![image](https://github.com/user-attachments/assets/c12d0e69-178d-46c8-8e41-bf20a92403ed)

- scale freq to 2500MHz
![image](https://github.com/user-attachments/assets/c041d3db-b114-4881-b464-699aceb91b28)


- scale freq to 625MHz
![image](https://github.com/user-attachments/assets/543b190b-07ea-42e8-b79a-efcadec71c93)

- before change the code, my ARM64 PC would failed to boot when acpi_cppc is enabled

![163bb6486ca06e03fd1f30d1d89a768](https://github.com/user-attachments/assets/4a461d5a-dcdc-47a7-8d0d-327c049eddc3)



