### PR TITLE
Add close_range(3) function

### DIFF
--- a/distrib/sets/lists/debug/mi
+++ b/distrib/sets/lists/debug/mi
@@ -2037,6 +2037,7 @@
 ./usr/libdata/debug/usr/tests/lib/libc/gen/t_arc4random.debug		tests-lib-debug		debug,atf,compattestfile
 ./usr/libdata/debug/usr/tests/lib/libc/gen/t_assert.debug		tests-lib-debug		debug,atf,compattestfile
 ./usr/libdata/debug/usr/tests/lib/libc/gen/t_basedirname.debug		tests-lib-debug		debug,atf,compattestfile
+./usr/libdata/debug/usr/tests/lib/libc/gen/t_close_range.debug		tests-lib-debug		debug,atf,compattestfile
 ./usr/libdata/debug/usr/tests/lib/libc/gen/t_closefrom.debug		tests-lib-debug		debug,atf,compattestfile
 ./usr/libdata/debug/usr/tests/lib/libc/gen/t_cpuset.debug		tests-lib-debug		debug,atf,compattestfile
 ./usr/libdata/debug/usr/tests/lib/libc/gen/t_ctype.debug		tests-lib-debug		debug,atf,compattestfile

--- a/distrib/sets/lists/tests/mi
+++ b/distrib/sets/lists/tests/mi
@@ -3096,6 +3096,7 @@
 ./usr/tests/lib/libc/gen/t_arc4random			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/gen/t_assert			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/gen/t_basedirname			tests-lib-tests		compattestfile,atf
+./usr/tests/lib/libc/gen/t_close_range			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/gen/t_closefrom			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/gen/t_cpuset			tests-lib-tests		compattestfile,atf
 ./usr/tests/lib/libc/gen/t_ctype			tests-lib-tests		compattestfile,atf

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -338,6 +338,7 @@ int	 pipe2(int *, int);
 #if defined(_NETBSD_SOURCE)
 int	 acct(const char *);
 int	 closefrom(int);
+int	 close_range(unsigned int, unsigned int, int);
 int	 des_cipher(const char *, char *, long, int);
 int	 des_setkey(const char *);
 void	 endusershell(void);

--- a/lib/libc/gen/close_range.3
+++ b/lib/libc/gen/close_range.3
@@ -1,0 +1,62 @@
+.Dd July 19, 2025
+.Dt CLOSE_RANGE 3
+.Os
+.Sh NAME
+.Nm close_range
+.Nd delete open file descriptors
+.Sh LIBRARY
+.Lb libc
+.Sh SYNOPSIS
+.In unistd.h
+.Ft int
+.Fn close_range "u_int first" "u_int last" "int flags"
+.Sh DESCRIPTION
+The
+.Fn close_range
+function deletes all open file descriptors between
+.Fa first
+and
+.Fa last
+inclusive, clamped to the range of open file descriptors.
+Any errors encountered while closing file descriptors are ignored.
+Supported
+.Fa flags :
+.Bl -tag -width ".Dv CLOSE_RANGE_CLOEXEC"
+.It Dv CLOSE_RANGE_CLOEXEC
+Set the close-on-exec flag on descriptors in the range instead of closing them.
+.It Dv CLOSE_RANGE_CLOFORK
+Set the close-on-fork flag on descriptors in the range instead of closing them.
+.El
+.Sh RETURN VALUES
+Upon successful completion,
+.Fn close_range
+returns a value
+of 0.
+Otherwise, a value of -1 is returned and the global variable
+.Va errno
+is set to indicate the error.
+.Sh ERRORS
+The
+.Fn close_range
+function
+will fail if:
+.Bl -tag -width Er
+.It Bq Er EINVAL
+The
+.Fa last
+argument is lower than the
+.Fa first
+argument.
+.It Bq Er EINVAL
+An invalid flag was set.
+.El
+.Sh SEE ALSO
+.Xr close 2
+.Xr closefrom 3
+.Sh HISTORY
+The
+.Fn close_range
+function comes from Linux and first appeared in
+.Fx 8.0
+and
+.Nx 11.0 .

--- a/lib/libc/gen/closefrom.c
+++ b/lib/libc/gen/closefrom.c
@@ -38,6 +38,17 @@ __RCSID("$NetBSD: closefrom.c,v 1.4 2018/01/17 01:24:29 kamil Exp $");
 #include <unistd.h>
 
 int
+close_range(unsigned int first, unsigned int last, int flags)
+{
+	struct fclose_range_args cr = {
+		.last	= last,
+		.flags	= flags
+	};
+
+	return (fcntl(first, F_CLOSE_RANGE, &cr));
+}
+
+int
 closefrom(int fd)
 {
 

--- a/sys/kern/sys_descrip.c
+++ b/sys/kern/sys_descrip.c
@@ -336,6 +336,7 @@ sys_fcntl(struct lwp *l, const struct sys_fcntl_args *uap, register_t *retval)
 	struct flock fl;
 	bool cloexec = false;
 	bool clofork = false;
+	struct fclose_range_args cr;
 
 	fd = SCARG(uap, fd);
 	cmd = SCARG(uap, cmd);
@@ -343,6 +344,31 @@ sys_fcntl(struct lwp *l, const struct sys_fcntl_args *uap, register_t *retval)
 	error = 0;
 
 	switch (cmd) {
+	case F_CLOSE_RANGE:
+		if (fd < 0)
+			return EINVAL;
+		error = copyin(SCARG(uap, arg), &cr, sizeof(cr));
+		if (error)
+			return error;
+		if (cr.flags & ~(CLOSE_RANGE_CLOEXEC|CLOSE_RANGE_CLOFORK))
+			return EINVAL;
+		if ((unsigned int)fd > cr.last)
+			return EINVAL;
+		cr.last = MIN(cr.last, fdp->fd_lastfile);
+		for (i = fd; i <= (int)cr.last; i++) {
+			fp = fd_getfile(i);
+			if (fp == NULL)
+				continue;
+			if (cr.flags != 0) {
+				fd_set_exclose(l, i,
+				    (cr.flags & CLOSE_RANGE_CLOEXEC) != 0);
+				fd_set_foclose(l, i,
+				    (cr.flags & CLOSE_RANGE_CLOFORK) != 0);
+				fd_putfile(i);
+			} else
+				fd_close(i);
+		}
+		return 0;
 	case F_CLOSEM:
 		if (fd < 0)
 			return EBADF;

--- a/sys/sys/fcntl.h
+++ b/sys/sys/fcntl.h
@@ -216,6 +216,14 @@
 #define	F_DUPFD_CLOBOTH	19		/* close on exec/fork duplicated fd */
 #endif
 
+#if defined(_NETBSD_SOURCE)
+#define F_CLOSE_RANGE	20		/* close_range(3) */
+struct fclose_range_args {
+	unsigned int last;		/* last file descriptor */
+	int flags;			/* CLOSE_RANGE_* flags */
+};
+#endif
+
 /* file descriptor flags (F_GETFD, F_SETFD) */
 #define	FD_CLOEXEC	1		/* close-on-exec flag */
 #define	FD_CLOFORK	2		/* close-on-fork flag */

--- a/sys/sys/unistd.h
+++ b/sys/sys/unistd.h
@@ -344,4 +344,10 @@
 /* configurable system strings */
 #define	_CS_PATH			   1
 
+#ifdef _NETBSD_SOURCE
+/* close_range(3) flags */
+#define CLOSE_RANGE_CLOEXEC	(1<<2)
+#define CLOSE_RANGE_CLOFORK	(1<<3)
+#endif
+
 #endif /* !_SYS_UNISTD_H_ */

--- a/tests/lib/libc/gen/Makefile
+++ b/tests/lib/libc/gen/Makefile
@@ -15,6 +15,7 @@ TESTS_C+=	t_arc4random
 TESTS_C+=	t_assert
 TESTS_C+=	t_basedirname
 TESTS_C+=	t_closefrom
+TESTS_C+=	t_close_range
 TESTS_C+=	t_cpuset
 TESTS_C+=	t_ctype
 TESTS_C+=	t_dir

--- a/tests/lib/libc/gen/t_close_range.c
+++ b/tests/lib/libc/gen/t_close_range.c
@@ -1,0 +1,275 @@
+/*-
+ * Copyright (c) 2011 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Jukka Ruohonen.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sys/cdefs.h>
+
+#include <sys/wait.h>
+
+#include <atf-c.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <unistd.h>
+
+static const char  path[] = "close_range";
+
+ATF_TC_WITH_CLEANUP(close_range_basic);
+ATF_TC_HEAD(close_range_basic, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "A basic test of close_range(2), #1");
+}
+
+ATF_TC_BODY(close_range_basic, tc)
+{
+	int fd, cur1, cur2;
+
+	(void)close_range(STDERR_FILENO + 1, UINT_MAX, 0);
+
+	fd = open(path, O_RDONLY | O_CREAT, 0400);
+	ATF_REQUIRE(fd >= 0);
+
+	cur1 = fcntl(0, F_MAXFD);
+
+	ATF_REQUIRE(cur1 == STDERR_FILENO + 1);
+	ATF_REQUIRE(close_range(cur1, UINT_MAX, 0) == 0);
+
+	cur2 = fcntl(0, F_MAXFD);
+
+	ATF_REQUIRE(cur1 - 1 == cur2);
+	ATF_REQUIRE(close(fd) == -1);
+	ATF_REQUIRE(unlink(path) == 0);
+}
+
+ATF_TC_CLEANUP(close_range_basic, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC_WITH_CLEANUP(close_range_buffer);
+ATF_TC_HEAD(close_range_buffer, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "A basic test of close_range(2), #2");
+}
+
+ATF_TC_BODY(close_range_buffer, tc)
+{
+	int buf[16], cur, half;
+	size_t i;
+
+	/*
+	 * Open a buffer of descriptors, close the half of
+	 * these and verify that the result is consistent.
+	 */
+	ATF_REQUIRE(close_range(STDERR_FILENO + 1, UINT_MAX, 0) == 0);
+
+	cur = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur == STDERR_FILENO);
+
+	for (i = 0; i < __arraycount(buf); i++) {
+		buf[i] = open(path, O_RDWR | O_CREAT, 0600);
+		ATF_REQUIRE(buf[i] >= 0);
+	}
+
+	cur = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur == __arraycount(buf) + STDERR_FILENO);
+
+	half = STDERR_FILENO + __arraycount(buf) / 2;
+	ATF_REQUIRE(close_range(half, UINT_MAX, 0) == 0);
+
+	cur = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur == half - 1);
+
+	for (i = 0; i < __arraycount(buf); i++)
+		(void)close(buf[i]);
+}
+
+ATF_TC_CLEANUP(close_range_buffer, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC(close_range_err);
+ATF_TC_HEAD(close_range_err, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test errors from close_range(2)");
+}
+
+ATF_TC_BODY(close_range_err, tc)
+{
+
+	errno = 0;
+	ATF_REQUIRE_ERRNO(EINVAL, close_range(UINT_MAX, 0, 0) == -1);
+}
+
+ATF_TC(close_range_one);
+ATF_TC_HEAD(close_range_one, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(1, UINT_MAX, 0)");
+}
+
+ATF_TC_BODY(close_range_one, tc)
+{
+	pid_t pid;
+	int sta;
+
+	pid = fork();
+	ATF_REQUIRE(pid >= 0);
+
+	if (pid == 0) {
+
+		if (close_range(1, UINT_MAX, 0) != 0)
+			_exit(10);
+
+		_exit(fcntl(0, F_MAXFD));
+	}
+
+
+	(void)wait(&sta);
+
+	/*
+	 * STDIN_FILENO should still be open; WEXITSTATUS(1) == 0.
+	 */
+	if (WIFEXITED(sta) == 0 || WEXITSTATUS(sta) != 0)
+		atf_tc_fail("not all descriptors were closed");
+}
+
+ATF_TC_WITH_CLEANUP(close_range_cloexec);
+ATF_TC_HEAD(close_range_cloexec, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(2) with CLOSE_RANGE_CLOEXEC");
+}
+
+ATF_TC_BODY(close_range_cloexec, tc)
+{
+	int fd, cur1, cur2;
+	int flags;
+
+	fd = open(path, O_RDONLY | O_CREAT, 0400);
+	ATF_REQUIRE(fd >= 0);
+
+	flags = fcntl(fd, F_GETFD);
+	ATF_REQUIRE(flags != -1);
+	ATF_REQUIRE(fcntl(fd, F_SETFD, flags | FD_CLOEXEC) != -1);
+
+	cur1 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == STDERR_FILENO + 1);
+	ATF_REQUIRE(close_range(cur1, UINT_MAX, CLOSE_RANGE_CLOEXEC) == 0);
+
+	cur2 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == cur2);
+
+	flags = fcntl(fd, F_GETFD);
+	ATF_REQUIRE(flags != -1);
+	ATF_CHECK((flags & FD_CLOEXEC) != 0);
+
+	ATF_REQUIRE(close(fd) == 0);
+	ATF_REQUIRE(unlink(path) == 0);
+}
+
+ATF_TC_CLEANUP(close_range_cloexec, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC_WITH_CLEANUP(close_range_invalid_flag);
+ATF_TC_HEAD(close_range_invalid_flag, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(2) with an invalid flag");
+}
+
+ATF_TC_BODY(close_range_invalid_flag, tc)
+{
+	int cur1, cur2;
+	int unused_flag = 0x40000000;
+
+	cur1 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == STDERR_FILENO);
+
+	errno = 0;
+	ATF_REQUIRE_ERRNO(EINVAL, close_range(STDERR_FILENO + 1, UINT_MAX, unused_flag) == -1);
+
+	cur2 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == cur2);
+}
+
+ATF_TC_CLEANUP(close_range_invalid_flag, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TC_WITH_CLEANUP(close_range_above);
+ATF_TC_HEAD(close_range_above, tc)
+{
+	atf_tc_set_md_var(tc, "descr", "Test close_range(2) doesn't close above a limit");
+}
+
+ATF_TC_BODY(close_range_above, tc)
+{
+	int fd, fd2;
+	int cur1, cur2;
+
+	fd = open(path, O_RDONLY | O_CREAT, 0400);
+	ATF_REQUIRE(fd >= 0);
+
+	fd2 = dup2(fd, 777);
+	ATF_REQUIRE(fd2 == 777);
+
+	cur1 = fcntl(0, F_MAXFD);
+
+	ATF_REQUIRE(close_range(fd + 1, fd2 - 1, 0) == 0);
+
+	cur2 = fcntl(0, F_MAXFD);
+	ATF_REQUIRE(cur1 == cur2);
+
+	ATF_REQUIRE(fcntl(fd, F_GETFD) != -1);
+	ATF_REQUIRE(close(fd) == 0);
+
+	ATF_REQUIRE(fcntl(fd2, F_GETFD) != -1);
+	ATF_REQUIRE(close(fd2) == 0);
+
+	ATF_REQUIRE(unlink(path) == 0);
+}
+
+ATF_TC_CLEANUP(close_range_above, tc)
+{
+	(void)unlink(path);
+}
+
+ATF_TP_ADD_TCS(tp)
+{
+
+	ATF_TP_ADD_TC(tp, close_range_basic);
+	ATF_TP_ADD_TC(tp, close_range_buffer);
+	ATF_TP_ADD_TC(tp, close_range_err);
+	ATF_TP_ADD_TC(tp, close_range_one);
+	ATF_TP_ADD_TC(tp, close_range_cloexec);
+	ATF_TP_ADD_TC(tp, close_range_invalid_flag);
+	ATF_TP_ADD_TC(tp, close_range_above);
+
+	return atf_no_error();
+}


### PR DESCRIPTION
Add close_range(3) function.  This uses the fcntl approach suggested to me by Robert Elz to avoid adding a new system call like in https://github.com/NetBSD/src/pull/43

The manpage was adapted from FreeBSD using the Linux names for the parameters:
https://man.freebsd.org/cgi/man.cgi?query=close_range&sektion=2&n=1

Fixes [kern/59081](https://gnats.netbsd.org/59081)