### PR TITLE
Fix memory leaks in create_resource_pool functions

### DIFF
--- a/sys/external/bsd/drm2/dist/drm/amd/display/dc/dce80/amdgpu_dce80_resource.c
+++ b/sys/external/bsd/drm2/dist/drm/amd/display/dc/dce80/amdgpu_dce80_resource.c
@@ -1115,6 +1115,7 @@ struct resource_pool *dce80_create_resource_pool(
 	if (dce80_construct(num_virtual_links, dc, pool))
 		return &pool->base;
 
+	kfree(pool);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }
@@ -1312,6 +1313,7 @@ struct resource_pool *dce81_create_resource_pool(
 	if (dce81_construct(num_virtual_links, dc, pool))
 		return &pool->base;
 
+	kfree(pool);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }
@@ -1505,6 +1507,7 @@ struct resource_pool *dce83_create_resource_pool(
 	if (dce83_construct(num_virtual_links, dc, pool))
 		return &pool->base;
 
+	kfree(pool);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/sys/external/bsd/drm2/dist/drm/amd/display/dc/dcn20/amdgpu_dcn20_resource.c
+++ b/sys/external/bsd/drm2/dist/drm/amd/display/dc/dcn20/amdgpu_dcn20_resource.c
@@ -3819,7 +3819,7 @@ struct resource_pool *dcn20_create_resource_pool(
 	if (dcn20_resource_construct(init_data->num_virtual_links, dc, pool))
 		return &pool->base;
 
-	BREAK_TO_DEBUGGER();
 	kfree(pool);
+	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/sys/external/bsd/drm2/dist/drm/amd/display/dc/dcn21/amdgpu_dcn21_resource.c
+++ b/sys/external/bsd/drm2/dist/drm/amd/display/dc/dcn21/amdgpu_dcn21_resource.c
@@ -1937,7 +1937,7 @@ struct resource_pool *dcn21_create_resource_pool(
 	if (dcn21_resource_construct(init_data->num_virtual_links, dc, pool))
 		return &pool->base;
 
-	BREAK_TO_DEBUGGER();
 	kfree(pool);
+	BREAK_TO_DEBUGGER();
 	return NULL;
 }


### PR DESCRIPTION
Fix missing kfree(pool) in resource pool creation paths (CVE-2019-19082)

Several resource pool creation functions were missing a kfree(pool) call when their corresponding *_construct() routines failed. In some cases, the free was placed after BREAK_TO_DEBUGGER(). This results in memory leaks on construction failure.

These issues mirror the leak pattern described in [CVE-2019-19082](https://nvd.nist.gov/vuln/detail/cve-2019-19082). This patch ensures the pool is always freed properly before returning NULL.

Changes made:

- dcn20_resource.c:
  * Move kfree(pool) before BREAK_TO_DEBUGGER().

- dcn21_resource.c:
  * Move kfree(pool) before BREAK_TO_DEBUGGER().

- dce80_resource.c:
  * Add missing kfree(pool) before BREAK_TO_DEBUGGER() in:
      - dce80_create_resource_pool()
      - dce81_create_resource_pool()
      - dce83_create_resource_pool()

