### PR TITLE
tests/kernel/t_mqueue: port to FreeBSD

### DIFF
--- a/tests/kernel/t_mqueue.c
+++ b/tests/kernel/t_mqueue.c
@@ -108,20 +108,15 @@ ATF_TC_HEAD(mqueue, tc)
 ATF_TC_BODY(mqueue, tc)
 {
 	int status;
-	char *tmpdir;
-	char template[32];
 	char mq_name[64];
 
-	strlcpy(template, "./t_mqueue.XXXXXX", sizeof(template));
-	tmpdir = mkdtemp(template);
-	ATF_REQUIRE_MSG(tmpdir != NULL, "mkdtemp failed: %d", errno);
-	snprintf(mq_name, sizeof(mq_name), "%s/mq", tmpdir);
+	snprintf(mq_name, sizeof(mq_name), "/t_mqueue.%d", getpid());
 
 	mqd_t mqfd;
 
 	mqfd = mq_open(mq_name, O_RDWR | O_CREAT,
 	    S_IRUSR | S_IRWXG | S_IROTH, NULL);
-	ATF_REQUIRE_MSG(mqfd != -1, "mq_open failed: %d", errno);
+	ATF_REQUIRE_MSG(mqfd != (mqd_t)-1, "mq_open(%s, ...) failed: %d", mq_name, errno);
 
 	send_msgs(mqfd);
 	receive_msgs(mqfd);


### PR DESCRIPTION
mq_open in FreeBSD and NetBSD both state that the path provided to the target mqueue should (in the POSIX parlance of "should") start with a /. In FreeBSD this proved to be more of an issue than NetBSD (especially when `kyua debug` was involved). Instead of relying on a temp directory which might exist outside the kyua sandbox, make the mqueue path absolute to the prefix `/t_mqueue` (for consistency with the test), and add the test PID to the path to avoid potential collisions between back-to-back / concurrent test runs.

While here, explicitly cast the checked return value to `mqd_t`: this is needed because some platforms--including FreeBSD--might define `mqd_t` as an unsigned type instead of a signed type. Casting it to `mqd_t` helps quell a valid compiler warning in that case.