### PR TITLE
tm(3): fix field name tm_isdt -> tm_isdst

### DIFF
--- a/share/man/man3/tm.3
+++ b/share/man/man3/tm.3
@@ -50,7 +50,7 @@ The following standards-compliant fields are present:
 .It Vt int Ta Va tm_year Ta Years since 1900 Ta
 .It Vt int Ta Va tm_wday Ta Days since Sunday Ta [0,  6]
 .It Vt int Ta Va tm_yday Ta Days since January 1 Ta [0, 365]
-.It Vt int Ta Va tm_isdt Ta Positive if daylight savings Ta >= 0
+.It Vt int Ta Va tm_isdst Ta Positive if daylight savings Ta >= 0
 .El
 .Pp
 The


### PR DESCRIPTION
Fixed the mistyped field name in the man page for struct tm.  Was tm_isdt, should be tm_isdst.