### PR TITLE
miscfs/nullfs: remove stale nullfs_init

### DIFF
--- a/sys/miscfs/nullfs/null.h
+++ b/sys/miscfs/nullfs/null.h
@@ -111,7 +111,5 @@ struct null_node {
 extern int (**null_vnodeop_p)(void *);
 extern struct vfsops nullfs_vfsops;
 
-void nullfs_init(void);
-
 #endif /* _KERNEL */
 #endif /* _MISCFS_NULLFS_H_ */


### PR DESCRIPTION
Couldn't find where this was implemented.

```
grep -r "nullfs_init" .
./sys/miscfs/nullfs/null.h:void nullfs_init(void);
```